### PR TITLE
content: publish budget-series articles 1-2; fix TOC header offset

### DIFF
--- a/data/articles.json
+++ b/data/articles.json
@@ -14,6 +14,36 @@
     "url": "/til/linearity-of-expectation-til.html"
   },
   {
+    "id": "monte-carlo-budget",
+    "title": "Why Your Budget Never Hits the Exact Number",
+    "description": "Monte Carlo simulation for budget planning — from point estimates to probability distributions.",
+    "category": "statistics",
+    "date": "2026-07-11",
+    "reading_time": "35 min",
+    "tags": [
+      "monte-carlo",
+      "simulation",
+      "probability",
+      "budgeting"
+    ],
+    "url": "/posts/monte-carlo-budget.html"
+  },
+  {
+    "id": "probabilistic-cost-modelling",
+    "title": "The Shape of What You'll Spend",
+    "description": "Probabilistic modelling of people costs — from distribution selection to budget impact.",
+    "category": "statistics",
+    "date": "2026-07-11",
+    "reading_time": "23 min",
+    "tags": [
+      "probability",
+      "distributions",
+      "heavy-tails",
+      "budgeting"
+    ],
+    "url": "/posts/probabilistic-cost-modelling.html"
+  },
+  {
     "id": "benfords-law",
     "title": "Benford's Law: two derivations, four tests, one fraud detector",
     "description": "Two independent derivations of Benford's leading-digit law, four conformity tests, and a fraud-detection demo on GeoNames city data.",

--- a/data/sources.json
+++ b/data/sources.json
@@ -5,14 +5,12 @@
     {
       "slug": "probabilistic-cost-modelling",
       "repo": "probabilistic-cost-modelling-article",
-      "path": "article/probabilistic-cost-modelling.md",
-      "draft": true
+      "path": "article/probabilistic-cost-modelling.md"
     },
     {
       "slug": "monte-carlo-budget",
       "repo": "monte-carlo-budget-article",
-      "path": "article/monte-carlo-budget.md",
-      "draft": true
+      "path": "article/monte-carlo-budget.md"
     },
     {
       "slug": "headcount-dynamics",

--- a/markdown_posts/monte-carlo-budget.md
+++ b/markdown_posts/monte-carlo-budget.md
@@ -8,45 +8,42 @@ tags: monte-carlo, simulation, probability, budgeting
 
 # Why Your Budget Never Hits the Exact Number
 
-## Monte Carlo Simulation for Budget Planning — from Point Estimates to Probability Distributions
+> **What this is.** The mathematical machinery to replace a single budget number with a probability distribution: "we expect to spend R\$ 11.5M" becomes "we are 90% confident spending will fall between R\$ 10.7M and R\$ 12.4M, with a 3% probability of exceeding the ceiling." The approach applies to any budget that decomposes into stochastic components — headcount, projects, procurement, infrastructure; an IT headcount budget is the running case study.
+>
+> **What you should know before reading.** *Required:* basic calculus (derivatives, integrals, a Taylor expansion) and basic probability (random variables, PDF/PMF, CDF, expectation, variance). *Helpful but not required:* prior exposure to the Law of Large Numbers, the Central Limit Theorem, and confidence intervals — all derived from first principles here — and working knowledge of NumPy. *Out of scope:* how to choose distributions for heavy-tailed data — that is the companion article [The Shape of What You'll Spend](probabilistic-cost-modelling.html) — plus Bayesian inference beyond a conceptual example, real-world data quality issues, and time-series forecasting.
+>
+> **What you will take away.** A working Monte Carlo budget you can build in a day, the proofs that justify trusting it, and the language to present a distribution to leadership as a reserve policy (P90 / P95 / P99) instead of a target.
+>
+> **Code.** Every figure and number is reproduced by versioned scripts with fixed seeds in the [companion repository](https://github.com/brunoramosmartins/monte-carlo-budget-article).
 
 ---
 
-## 0. What You Need to Know
+## Notation
 
-This article assumes familiarity with:
+| Symbol | Meaning |
+|--------|---------|
+| $X_{\text{total}}$ | Total budget cost (random variable) |
+| $X_k$ | Cost of component $k$ |
+| $n$ | Number of units (headcount, items, etc.) |
+| $\bar{X}_N$ | Sample mean of $N$ simulations |
+| $\hat{\theta}_N$ | Monte Carlo estimator |
+| $\sigma$ | Standard deviation of the cost distribution |
+| $z_{\alpha/2}$ | Normal quantile for confidence level $1-\alpha$ |
 
-**Required:**
-- Basic calculus: derivatives, integrals, Taylor expansion (used in §4–§5)
-- Basic probability: random variables, PDF / PMF, CDF, expectation, variance
-- Reading mathematical notation comfortably
+**Case study notation** (IT headcount):
 
-**Helpful but not required:**
-- Prior exposure to the Law of Large Numbers and the Central Limit Theorem (both are derived from first principles in §4 and §5)
-- Familiarity with confidence intervals (derived in §5)
-- Working knowledge of NumPy (used in the implementation, but the article is readable without it)
-
-**Out of scope (won't be covered):**
-- Heavy-tailed distributions and how to choose them — see the companion article on distribution selection
-- Bayesian inference beyond a conceptual update example (§8)
-- Real-world data quality issues (NDA, censoring, reporting noise)
-- Time-series forecasting (rolling regimes, ARIMA, state-space models)
-
-### Reading Guide
-
-The article works at three levels of depth. Pick what suits you.
-
-| If you are… | Read | Skip / skim |
-|------------|------|--------------|
-| A budget owner / executive | §1, §2, §9 (results), §10 (framework), §11 | The proofs in §4 and §5 — read only the takeaway notes |
-| An analyst applying the method | §1–§3, §6, §7, §9, §10 | The MGF proof in §5 |
-| A reader auditing the math | All sections in order | Nothing |
-
-The figures and the "How to Present Results" passage in §10 are the highest-value pieces for a quick read.
+| Symbol | Meaning |
+|--------|---------|
+| $S_i$ | Monthly salary of employee $i$ |
+| $\beta$ | Benefits multiplier |
+| $H_i$ | Overtime hours per employee per month |
+| $r_{ot}$ | Overtime hourly rate |
+| $I$ | Number of severe incidents per year |
+| $C_j$ | Cost of incident $j$ |
 
 ---
 
-## 1. Introduction
+## Introduction
 
 Someone asks for next year's budget. You open a spreadsheet, multiply quantities by unit costs, add contingencies, round up a little — and deliver a number. A single number.
 
@@ -72,34 +69,11 @@ This article replaces the single number with a **probability distribution**. Usi
 
 The approach is **general**: it applies to any budget that can be decomposed into stochastic components — headcount, projects, procurement, licensing, infrastructure. We illustrate with an IT headcount budget (salaries, benefits, overtime, incidents) as a concrete case study, but the mathematical framework transfers directly to any domain.
 
-The journey proceeds in four stages: we formalise budget components as random variables (Section 3), prove that averaging simulations converges to the true answer (Section 4), quantify the simulation error (Section 5), and implement the estimator with variance reduction techniques (Sections 6–7). Section 9 validates everything experimentally; Section 10 turns the math into a decision framework you can hand to a budget owner on Monday morning.
-
-### Notation
-
-| Symbol | Meaning |
-|--------|---------|
-| $X_{\text{total}}$ | Total budget cost (random variable) |
-| $X_k$ | Cost of component $k$ |
-| $n$ | Number of units (headcount, items, etc.) |
-| $\bar{X}_N$ | Sample mean of $N$ simulations |
-| $\hat{\theta}_N$ | Monte Carlo estimator |
-| $\sigma$ | Standard deviation of the cost distribution |
-| $z_{\alpha/2}$ | Normal quantile for confidence level $1-\alpha$ |
-
-**Case study notation** (IT headcount):
-
-| Symbol | Meaning |
-|--------|---------|
-| $S_i$ | Monthly salary of employee $i$ |
-| $\beta$ | Benefits multiplier |
-| $H_i$ | Overtime hours per employee per month |
-| $r_{ot}$ | Overtime hourly rate |
-| $I$ | Number of severe incidents per year |
-| $C_j$ | Cost of incident $j$ |
+The journey proceeds in stages: we formalise [budget components as random variables](#budget-components-as-random-variables), prove that averaging simulations converges to the true answer with [the Law of Large Numbers](#the-law-of-large-numbers), quantify the simulation error with [the Central Limit Theorem](#the-central-limit-theorem), and make the estimator efficient with [variance reduction](#variance-reduction). The [experiments](#experiments-and-results) validate everything; [the practical framework](#a-practical-framework) turns the math into a decision workflow you can hand to a budget owner on Monday morning.
 
 ---
 
-## 2. The Point Estimate Problem
+## The Point Estimate Problem
 
 A point estimate is a single value used to approximate an unknown parameter. In budget planning, it takes the form:
 
@@ -148,7 +122,7 @@ where $g_k$ is a cost function for component $k$ and $\mathbf{Z}_k$ is a vector 
 
 ---
 
-## 3. Budget Components as Random Variables
+## Budget Components as Random Variables
 
 Every component of a budget is potentially a random variable. Treating them as constants is a modelling choice that discards information. The key insight: **identify which components carry meaningful uncertainty, model them probabilistically, and keep the rest deterministic.**
 
@@ -258,13 +232,13 @@ The same structure applies to:
 
 In each case: identify the random components, choose distributions, and simulate.
 
-A short caveat before moving on. Everything that follows assumes the distributions chosen for each component are *correct*. Monte Carlo will faithfully simulate from whatever you feed it — including a bad model. A LogNormal salary fit to data that is actually heavy-tailed will produce a CI that looks tight and is wrong. The companion article on distribution selection and heavy tails treats this question directly — how to pick a distribution from data, when to suspect a heavier tail than your eye says, and what happens to risk estimates when you get it wrong. If you only have time to read one, read this one first; the companion is what stops you from being precisely wrong.
+A short caveat before moving on. Everything that follows assumes the distributions chosen for each component are *correct*. Monte Carlo will faithfully simulate from whatever you feed it — including a bad model. A LogNormal salary fit to data that is actually heavy-tailed will produce a CI that looks tight and is wrong. The companion article [The Shape of What You'll Spend](probabilistic-cost-modelling.html) treats this question directly — how to pick a distribution from data, when to suspect a heavier tail than your eye says, and what happens to risk estimates when you get it wrong. If you only have time to read one, read this one first; the companion is what stops you from being precisely wrong.
 
-With the model defined, the next two sections answer the two questions any practitioner asks before trusting a simulation: *will the average converge?* (Section 4, the Law of Large Numbers) and *how confident can I be after $N$ runs?* (Section 5, the Central Limit Theorem).
+With the model defined, the next two sections answer the two questions any practitioner asks before trusting a simulation: *will the average converge?* (the Law of Large Numbers) and *how confident can I be after $N$ runs?* (the Central Limit Theorem).
 
 ---
 
-## 4. Will the Mean Converge? The Law of Large Numbers
+## The Law of Large Numbers
 
 If we simulate the budget 10,000 times and average the results, will the average converge to the true $E[X_{\text{total}}]$? The Law of Large Numbers says yes.
 
@@ -292,14 +266,13 @@ The Strong Law provides an even stronger guarantee: $\bar{X}_N \to \mu$ almost s
 
 **For Monte Carlo:** each simulation $X_i$ is one "possible year." The LLN guarantees that averaging $N$ simulated scenarios converges to the true expected cost.
 
-![LLN Convergence](../figures/monte-carlo-budget/lln_convergence.png)
-*Figure 1: Ten independent runs of the sample mean converging to $E[X]$, with Chebyshev 95% confidence band.*
+![Ten independent runs of the sample mean converging to E[X], with the Chebyshev 95% confidence band.](../figures/lln_convergence.png)
 
 The LLN guarantees we get the right answer eventually. It does not tell us how close we are after, say, $N = 1{,}000$ runs — Chebyshev's bound is a worst case across all distributions, not a sharp estimate. To answer "how confident can I be?" we need the *shape* of the error, not just its decay. That is what the Central Limit Theorem provides.
 
 ---
 
-## 5. How Wrong Can We Be? The Central Limit Theorem
+## The Central Limit Theorem
 
 The LLN tells us the estimate converges. The CLT tells us **how fast** — and gives us confidence intervals.
 
@@ -353,14 +326,13 @@ $$
 
 For our case study ($\sigma \approx 493K$, $\epsilon = 100K$, 95%): $N \geq 94$. Remarkably few simulations are needed.
 
-![CLT Normality Emergence](../figures/monte-carlo-budget/clt_normality_emergence.png)
-*Figure 2: As $n$ increases, the standardised sample mean converges to $N(0,1)$.*
+![As N increases, the standardised sample mean converges to the standard Normal distribution.](../figures/monte-carlo-budget/clt_normality_emergence.png)
 
-With the LLN giving convergence and the CLT giving the error rate, the Monte Carlo estimator is fully specified. We can finally state its formal properties — and address the quiet question of when, despite all this, the estimator can still produce confidently wrong answers.
+With the LLN giving convergence and the CLT giving the error rate, the Monte Carlo estimator is fully specified. We can now state its formal properties.
 
 ---
 
-## 6. The Monte Carlo Estimator
+## The Monte Carlo Estimator
 
 ### Definition
 
@@ -392,27 +364,11 @@ Halving the CI width requires 4× more simulations. This fundamental trade-off m
 
 Since the estimator is unbiased: $\text{MSE}(\hat{\theta}_N) = \sigma_g^2 / N$.
 
-### When Monte Carlo Fails
-
-Monte Carlo is a faithful estimator of $E[g(X)]$ given a model. It is *not* a check that the model is right. The estimator can be unbiased, consistent, and asymptotically normal — and still produce conclusions that are confidently wrong. The most common failure modes:
-
-1. **Misspecified distribution.** You picked Normal where the truth is heavy-tailed, or used a Poisson rate calibrated on a quiet year. The simulated CI shrinks around a centre that is wrong; everything downstream inherits the bias. *Mitigation:* fit distributions on multi-year data when possible, plot Q-Q against the proposed distribution, and run a sensitivity to alternative families (LogNormal vs Gamma vs heavy-tailed Pareto).
-
-2. **Ignored correlation.** Treating components as independent when they covary positively under-estimates variance. The CI looks tight — and breaks at the first joint shock. *Mitigation:* when in doubt, re-run with a Gaussian copula at the maximum plausible correlation. If the P95 moves materially, model it; if not, document the assumption.
-
-3. **Heavy tails the model does not capture.** Heavy-tailed phenomena (incident severities, FX shocks, project overruns) can violate the variance-finite assumption that underpins the CLT. The sample mean still converges, but the CI based on $z_{\alpha/2} \sigma / \sqrt{N}$ is over-confident. *Mitigation:* check the empirical tail decay; if it looks polynomial rather than exponential, switch to a heavy-tailed family (Pareto, Student-$t$). The companion article on distribution selection covers this directly.
-
-4. **Pilot variance under-estimates true variance.** The minimum-$N$ formula $N \geq (z \sigma / \epsilon)^2$ uses a sample $\sigma$ from the pilot run. If the pilot was small or unlucky, $\sigma$ is low-biased — and the actual CI is wider than promised. *Mitigation:* always re-check the CI half-width *after* the full run. If it overshoots the target, run more.
-
-5. **The decision is not in the bulk.** Monte Carlo gives best precision at the centre of the distribution and worst at the tails. Decisions framed around the median or mean (e.g., "expected cost") are reliable; decisions framed around extreme percentiles (e.g., "1-in-1000-year shortfall") need much larger $N$ to estimate the same percentile with the same precision. *Mitigation:* if you care about extreme tails, switch to importance sampling or extreme-value theory — naive MC is not the right tool.
-
-The honest claim is narrower than "Monte Carlo gives the answer". It is: *Monte Carlo gives the answer that the model implies*. Failures upstream of the simulation — wrong distribution, wrong dependencies, wrong tail — are not detected by the simulation itself. Validate them separately.
-
-With those caveats acknowledged, the estimator does work — but the $O(1/\sqrt{N})$ rate is harsh. Every halving of the CI requires quadrupling the simulations, and at the precision needed for serious budget decisions that gets expensive fast. The next section shows how to break that ceiling without changing $N$.
+The estimator is unbiased, consistent, and asymptotically Normal — everything the theory can promise. What the theory cannot promise is that the *model being simulated* is right; [Limitations](#limitations) catalogues the ways that assumption fails in practice. Before that, there is a performance ceiling to break: the $O(1/\sqrt{N})$ rate is harsh — every halving of the CI requires quadrupling the simulations, and at the precision needed for serious budget decisions that gets expensive fast. The next section shows how to break that ceiling without changing $N$.
 
 ---
 
-## 7. Making It Faster: Variance Reduction
+## Variance Reduction
 
 The $O(1/\sqrt{N})$ rate means brute-force precision is expensive. Variance reduction techniques achieve tighter confidence intervals **for the same computational budget**.
 
@@ -458,8 +414,7 @@ $$
 
 Always. Stratification removes between-strata variance.
 
-![Variance Reduction Comparison](../figures/monte-carlo-budget/variance_reduction_comparison.png)
-*Figure 3: CI width vs N for naive MC, antithetic variates, and control variates.*
+![95% CI width versus N for naive Monte Carlo, antithetic variates, and control variates.](../figures/monte-carlo-budget/variance_reduction_comparison.png)
 
 ### Why This Matters Beyond the Math: Compute ROI
 
@@ -477,18 +432,18 @@ Suppose the naive simulation needs $N = 30{,}000$ runs to deliver a ±R$ 50K con
 The ROI is not the variance number; it is what the variance number *enables*:
 
 - **Live dashboards.** A CFO sliding a headcount parameter and watching the P95 update in milliseconds is a different product from one that takes a coffee break to recompute.
-- **Sensitivity at scale.** Section 9's sensitivity analysis runs the simulation many times, once per parameter variation. Cutting each run by 50× turns an overnight batch into a few-second screen.
+- **Sensitivity at scale.** The [sensitivity analysis in the experiments](#experiments-and-results) runs the simulation many times, once per parameter variation. Cutting each run by 50× turns an overnight batch into a few-second screen.
 - **Cheap A/B of model assumptions.** Want to compare LogNormal vs Gamma for salaries? Naive MC makes that a meeting; control variates make it a parameter toggle.
 
 The math justifies the technique. The compute economics is what gets it shipped.
 
-So far, the simulation is built once, before the year starts — a static distribution that anchors a one-shot decision. But budgets are not one-shot artefacts; they are revisited every month as real spending data arrives. The next section reframes the same machinery as the *first version* of a budget that gets updated continuously, a Bayesian extension that turns the one-shot script into a living forecast.
+So far, the simulation is built once, before the year starts — a static distribution that anchors a one-shot decision. But budgets are not one-shot artefacts; they are revisited every month as real spending data arrives. The next section reframes the same machinery as the *first version* of a budget that gets updated continuously — a Bayesian extension that turns the one-shot script into a living forecast.
 
 ---
 
-## 8. Phase 2 Maturity: Continuous Budget Updating
+## Continuous Budget Updating
 
-Everything so far built the **first version** of the budget: a probability distribution computed *before* the year starts, from a fixed model. Sections 4–7 made that estimate convergent, calibrated, and efficient.
+Everything so far built the **first version** of the budget: a probability distribution computed *before* the year starts, from a fixed model. The previous sections made that estimate convergent, calibrated, and efficient.
 
 But a budget is not a one-shot artefact. Each month produces actual spending data. Each quarter brings forecast revisions. The static distribution from January is *not* the right belief in July — by then we have evidence.
 
@@ -504,7 +459,7 @@ $$
 
 Read in budget terms:
 
-- **Prior $P(\theta)$** — the distribution from January. The output of the Monte Carlo simulation in Section 9, *re-cast as a belief about the world*.
+- **Prior $P(\theta)$** — the distribution from January. The output of the full simulation in [Experiments and Results](#experiments-and-results), *re-cast as a belief about the world*.
 - **Likelihood $P(\text{data} \mid \theta)$** — how plausible the spending observed so far is, under each candidate value of $\theta$.
 - **Posterior $P(\theta \mid \text{data})$** — the updated distribution after the data arrives. This becomes the prior for the next month.
 
@@ -522,10 +477,10 @@ The posterior mean is a **precision-weighted average** of the prior mean and the
 
 By month 6, the posterior is much narrower than the original prior. By month 12, the year is over and the posterior collapses around the realised cost. The trajectory of posteriors *is* the forecast.
 
-### Frequentist (Phase 1) vs Bayesian (Phase 2): When Each Fits
+### Static Simulation vs Bayesian Updating: When Each Fits
 
-| Aspect | Phase 1: Frequentist MC (Sections 1–7) | Phase 2: Bayesian update (this section) |
-|--------|----------------------------------------|------------------------------------------|
+| Aspect | Static simulation (this article's core) | Bayesian update layer (this section) |
+|--------|------------------------------------------|------------------------------------------|
 | Parameters | Fixed constants of the model | Random variables with their own distributions |
 | Prior information | Encoded implicitly in distribution choice | Explicit, auditable, can incorporate history |
 | Output | Confidence interval | Credible interval (direct probability of $\theta$) |
@@ -533,68 +488,75 @@ By month 6, the posterior is much narrower than the original prior. By month 12,
 | Best when | Building the *first* budget; no usable history | Updating an *existing* budget with monthly data |
 | Cost | A single Monte Carlo run | A simulation engine **plus** a data pipeline |
 
-### Why This Matters for the Portfolio Reader
+### Why This Matters
 
-A team that ships only the Phase 1 simulation has built a script. A team that ships Phase 1 *and* Phase 2 has built a **data product** — a model that lives across the fiscal year, gets better with data, and produces decisions, not just numbers.
+A team that ships only the static simulation has built a script. A team that ships the simulation *and* the updating layer has built a **data product** — a model that lives across the fiscal year, gets better with data, and produces decisions, not just numbers.
 
-This article focuses on Phase 1 because Phase 2 inherits its rigour: a Bayesian update on top of a badly-calibrated prior is just a slow way to be wrong. Get the simulation right first; the lifecycle layer is then a small addition. Section 10 returns to this lifecycle view in the practical framework.
+This article focuses on the static simulation because the updating layer inherits its rigour: a Bayesian update on top of a badly-calibrated prior is just a slow way to be wrong. Get the simulation right first; the lifecycle layer is then a small addition. [A Practical Framework](#a-practical-framework) returns to this lifecycle view.
 
-Theory and reframing aside, the question that decides whether any of this matters is: *does the engine actually work?* The next section answers it experimentally — five controlled studies covering convergence, normality emergence, full simulation, variance reduction, and sensitivity, each with explicit setup, metric, and result.
+Theory and reframing aside, the question that decides whether any of this matters is: *does the engine actually work?* The next section answers it experimentally — five controlled studies covering convergence, normality emergence, full simulation, variance reduction, and sensitivity.
 
 ---
 
-## 9. Experiments and Results
+## Experiments and Results
 
-Each experiment follows the same template — **Objective**, **Setup**, **Metric**, **Result** — so the validation reads as a study, not a demo. All runs use fixed seeds; the corresponding scripts in `scripts/` reproduce every figure exactly.
+Each experiment follows the same template — **Claim**, **Setup**, **Result**, **Connection** — so the validation reads as a study, not a demo. All runs use fixed seeds; the corresponding scripts in `scripts/` reproduce every figure exactly.
 
 ### Experiment A — LLN Convergence
 
-- **Objective:** show that the sample mean converges to the analytical $E[X]$ as $N$ grows, with variance shrinking at rate $O(1/\sqrt{N})$.
-- **Setup:** 10 independent runs of LogNormal salary draws, $N$ from 1 to 10,000 each. Chebyshev 95% band overlaid.
-- **Metric:** absolute deviation $|\bar{X}_n - E[X]|$ across runs.
-- **Result:** at small $N$, runs spread widely; by $N = 5{,}000$, all 10 runs cluster within R$ 200 of the analytical mean. The empirical decay matches $\sigma/\sqrt{n}$ on a log-log plot.
+**Claim.** The sample mean converges to the analytical $E[X]$ as $N$ grows, with variance shrinking at rate $O(1/\sqrt{N})$.
 
-*See Figure 1.*
+**Setup.** 10 independent runs of LogNormal salary draws, $N$ from 1 to 10,000 each; absolute deviation $|\bar{X}_n - E[X]|$ tracked across runs, with the Chebyshev 95% band overlaid.
+
+**Result.** At small $N$, runs spread widely; by $N = 5{,}000$, all 10 runs cluster within R$ 200 of the analytical mean. The empirical decay matches $\sigma/\sqrt{n}$ on a log-log plot.
+
+**Connection.** The Weak Law proved in [The Law of Large Numbers](#the-law-of-large-numbers), observed at finite $N$ (the figure lives in that section).
 
 ### Experiment B — CLT Normality
 
-- **Objective:** verify that the standardised sample mean of LogNormal draws converges in distribution to $N(0, 1)$.
-- **Setup:** 10,000 repetitions of "draw $n$ LogNormals, standardise the mean", for $n \in \{1, 5, 10, 30, 100\}$. Histogram + QQ-plot per $n$.
-- **Metric:** linearity of the QQ-plot (regression $R^2$) and visual fit to the standard Normal density.
-- **Result:** visibly non-Normal at $n = 1$; by $n = 30$, the histogram closely tracks $N(0,1)$; at $n = 100$, $R^2 \gt 0.999$.
+**Claim.** The standardised sample mean of LogNormal draws converges in distribution to $N(0, 1)$ — right-skewed costs in, bell curve out.
 
-*See Figure 2.*
+**Setup.** 10,000 repetitions of "draw $n$ LogNormals, standardise the mean", for $n \in \{1, 5, 10, 30, 100\}$; histogram and QQ-plot per $n$, with QQ linearity ($R^2$) as the fit metric.
+
+**Result.** Visibly non-Normal at $n = 1$; by $n = 30$, the histogram closely tracks $N(0,1)$; at $n = 100$, $R^2 \gt 0.999$.
+
+**Connection.** The MGF proof in [The Central Limit Theorem](#the-central-limit-theorem), watched happening (the figure lives in that section).
 
 ### Experiment C — Full Budget Simulation
 
-- **Objective:** estimate the full distribution of $X_{\text{total}}$, not just its mean — and quantify the probability of exceeding a ceiling.
-- **Setup:** $N = 50{,}000$ iterations of the IT headcount budget model with default parameters, seed 42. Ceiling at R$ 12.5M.
-- **Metric:** relative error of MC mean vs analytical $E[X]$, 95% CI half-width, P5–P95 range, $P(X \gt \text{ceiling})$.
-- **Result:** MC mean within 0.1% of analytical. 95% CI half-width approximately R$ 4K. P5–P95 spans ~R$ 1.6M. The probability of exceeding R$ 12.5M is approximately 3%. The distribution is right-skewed.
+**Claim.** Monte Carlo recovers the full distribution of $X_{\text{total}}$ — not just its mean — including the ceiling-breach probability no point estimate can produce.
 
-![Budget Simulation](../figures/monte-carlo-budget/budget_simulation.png)
-*Figure 4: Budget cost distribution (histogram + CDF) with mean, P5/P95, and budget ceiling annotated.*
+**Setup.** $N = 50{,}000$ iterations of the IT headcount budget model with default parameters, seed 42; ceiling at R$ 12.5M; metrics: relative error of the MC mean vs analytical $E[X]$, 95% CI half-width, P5–P95 range, $P(X \gt \text{ceiling})$.
+
+**Result.** MC mean within 0.1% of analytical. 95% CI half-width approximately R$ 4K. P5–P95 spans ~R$ 1.6M. The probability of exceeding R$ 12.5M is approximately 3%. The distribution is right-skewed.
+
+**Connection.** Instantiates the full model of [Budget Components as Random Variables](#budget-components-as-random-variables) and delivers the risk profile promised in [The Point Estimate Problem](#the-point-estimate-problem).
+
+![Budget cost distribution (histogram and CDF) with mean, P5/P95, and the budget ceiling annotated.](../figures/monte-carlo-budget/budget_simulation.png)
 
 ### Experiment D — Variance Reduction
 
-- **Objective:** measure the speedup from control variates and antithetic variates against naive MC at matched $N$.
-- **Setup:** all three methods at $N \in \{500, 1{,}000, 2{,}000, 5{,}000, 10{,}000\}$. Control variate: total raw salary sum (analytical mean known).
-- **Metric:** 95% CI half-width per method, plotted against $N$ on log-log axes.
-- **Result:** control variates reduce CI width by approximately **5–6×** at every $N$ tested (corresponding to a ~30× variance reduction; effective $\rho \approx 0.99$). The antithetic implementation overlaps closely with naive MC — its modest gain reflects that the budget model's compound Poisson structure is hard to "mirror" cleanly with seed-based pairing. The slope on log-log is $-1/2$ for all methods, confirming the $O(1/\sqrt{N})$ rate — variance reduction shifts the *intercept*, not the rate.
+**Claim.** Control variates deliver an order-of-magnitude variance reduction at matched $N$; the $O(1/\sqrt{N})$ rate itself does not change.
 
-*See Figure 3.*
+**Setup.** Naive MC, antithetic variates, and control variates at $N \in \{500, 1{,}000, 2{,}000, 5{,}000, 10{,}000\}$; control variate: total raw salary sum (analytical mean known); metric: 95% CI half-width per method on log-log axes.
+
+**Result.** Control variates reduce CI width by approximately **5–6×** at every $N$ tested (corresponding to a ~30× variance reduction; effective $\rho \approx 0.99$). The antithetic implementation overlaps closely with naive MC — its modest gain reflects that the budget model's compound Poisson structure is hard to "mirror" cleanly with seed-based pairing. The slope on log-log is $-1/2$ for all methods, confirming the $O(1/\sqrt{N})$ rate — variance reduction shifts the *intercept*, not the rate.
+
+**Connection.** The control-variate formula of [Variance Reduction](#variance-reduction) at work (the figure lives in that section); the dominant-component pattern from the case study is exactly why the salary control works so well.
 
 ### Experiment E — Sensitivity Analysis
 
-- **Objective:** rank model parameters by their impact on $E[X_{\text{total}}]$ to guide where to spend modelling effort.
-- **Setup:** vary the **effective contribution** of each of 8 parameters by ±20% (for log-mean parameters, this is an additive shift of $\ln(1.2)$; for linear parameters, a multiplicative scale). Hold all others fixed. Run $N = 10{,}000$ per variation.
-- **Metric:** percentage change in $E[X_{\text{total}}]$ relative to the base case.
-- **Result:** three parameters dominate, each producing roughly the same ±19–20% swing in $E[X_{\text{total}}]$: the salary mean ($\mu_s$ via $E[S]$), the benefits multiplier ($\beta$), and the headcount ($n$). All three act linearly on the salary component, which is ~97% of the budget. Overtime and incident parameters change the total by less than 1%. **Practical implication:** invest modelling effort in the three salary-cost levers; refining the overtime or incident model is rounding error.
+**Claim.** A small number of parameters dominates the total budget; sensitivity analysis tells the analyst where modelling effort pays.
+
+**Setup.** The **effective contribution** of each of 8 parameters varied by ±20% (for log-mean parameters, an additive shift of $\ln(1.2)$; for linear parameters, a multiplicative scale), all others held fixed; $N = 10{,}000$ per variation; metric: percentage change in $E[X_{\text{total}}]$ vs the base case.
+
+**Result.** Three parameters dominate, each producing roughly the same ±19–20% swing in $E[X_{\text{total}}]$: the salary mean ($\mu_s$ via $E[S]$), the benefits multiplier ($\beta$), and the headcount ($n$). All three act linearly on the salary component, which is ~97% of the budget. Overtime and incident parameters change the total by less than 1%. **Practical implication:** invest modelling effort in the three salary-cost levers; refining the overtime or incident model is rounding error.
+
+**Connection.** Feeds directly into step 1 of [A Practical Framework](#a-practical-framework) — decompose and find what matters — and is only computationally feasible because of [Variance Reduction](#variance-reduction).
 
 > **Why "effective ±20%" and not raw ±20%?** The salary log-mean $\mu_s$ enters $E[S] = e^{\mu_s + \sigma_s^2/2}$ exponentially. Varying $\mu_s$ by ±20% additively would multiply $E[S]$ by $\approx 6.3\times$ — making the chart visually dominated by $\mu_s$ for a non-business reason. The corrected setup varies the *effective expected value* of each component, so the ranking reflects business sensitivity, not parameter scale.
 
-![Sensitivity Tornado](../figures/monte-carlo-budget/sensitivity_tornado.png)
-*Figure 5: Tornado chart showing parameter impact on $E[X_{\text{total}}]$.*
+![Tornado chart ranking each parameter's impact on the expected total budget.](../figures/monte-carlo-budget/sensitivity_tornado.png)
 
 ### Key Findings
 
@@ -612,7 +574,7 @@ The experiments confirm the engine works. The remaining gap is operational: turn
 
 ---
 
-## 10. A Practical Framework for Budget Analysts
+## A Practical Framework
 
 ### When to Use Monte Carlo
 
@@ -702,7 +664,25 @@ If those numbers are useful, you have just earned the right to invest in v2 — 
 
 ---
 
-## 11. Conclusion
+## Limitations
+
+Monte Carlo is a faithful estimator of $E[g(X)]$ *given a model*. It is **not** a check that the model is right. The estimator can be unbiased, consistent, and asymptotically normal — and still produce conclusions that are confidently wrong. The most common failure modes:
+
+1. **Misspecified distribution.** You picked Normal where the truth is heavy-tailed, or used a Poisson rate calibrated on a quiet year. The simulated CI shrinks around a centre that is wrong; everything downstream inherits the bias. *Mitigation:* fit distributions on multi-year data when possible, plot Q-Q against the proposed distribution, and run a sensitivity to alternative families (LogNormal vs Gamma vs heavy-tailed Pareto).
+
+2. **Ignored correlation.** Treating components as independent when they covary positively under-estimates variance. The CI looks tight — and breaks at the first joint shock. *Mitigation:* when in doubt, re-run with a Gaussian copula at the maximum plausible correlation. If the P95 moves materially, model it; if not, document the assumption.
+
+3. **Heavy tails the model does not capture.** Heavy-tailed phenomena (incident severities, FX shocks, project overruns) can violate the variance-finite assumption that underpins the CLT. The sample mean still converges, but the CI based on $z_{\alpha/2} \sigma / \sqrt{N}$ is over-confident. *Mitigation:* check the empirical tail decay; if it looks polynomial rather than exponential, switch to a heavy-tailed family (Pareto, Student-$t$). The companion article [The Shape of What You'll Spend](probabilistic-cost-modelling.html) covers this directly.
+
+4. **Pilot variance under-estimates true variance.** The minimum-$N$ formula $N \geq (z \sigma / \epsilon)^2$ uses a sample $\sigma$ from the pilot run. If the pilot was small or unlucky, $\sigma$ is low-biased — and the actual CI is wider than promised. *Mitigation:* always re-check the CI half-width *after* the full run. If it overshoots the target, run more.
+
+5. **The decision is not in the bulk.** Monte Carlo gives best precision at the centre of the distribution and worst at the tails. Decisions framed around the median or mean (e.g., "expected cost") are reliable; decisions framed around extreme percentiles (e.g., "1-in-1000-year shortfall") need much larger $N$ to estimate the same percentile with the same precision. *Mitigation:* if you care about extreme tails, switch to importance sampling or extreme-value theory — naive MC is not the right tool.
+
+The honest claim is narrower than "Monte Carlo gives the answer". It is: *Monte Carlo gives the answer that the model implies*. Failures upstream of the simulation — wrong distribution, wrong dependencies, wrong tail — are not detected by the simulation itself. Validate them separately.
+
+---
+
+## Conclusion
 
 A single-number budget is an **incomplete model**. It compresses a distribution into its centre, throws away every tail, and asks the organisation to make capital allocation decisions on what is left.
 
@@ -718,29 +698,17 @@ Three sentences. Print them above the spreadsheet.
 
 Any serious budget should be expressed as a distribution. Any serious budget review should ask "where in the distribution did we land?", not "by how much did we miss?". And any serious team building a budget today should be running the kind of simulation this article describes — by Monday, on a laptop, in a hundred lines of Python.
 
-The next time someone asks for a budget number, give them a distribution.
+The next time someone asks for a budget number, give them a distribution. And when you are ready to choose *which* distributions to feed the simulation, the companion article [The Shape of What You'll Spend](probabilistic-cost-modelling.html) is the natural next read.
 
 ---
 
 ## References
 
-1. Casella, G. & Berger, R. (2002). *Statistical Inference*. Duxbury.
-2. Robert, C. & Casella, G. (2004). *Monte Carlo Statistical Methods*. Springer.
-3. Glasserman, P. (2003). *Monte Carlo Methods in Financial Engineering*. Springer.
-4. Gelman, A. et al. (2013). *Bayesian Data Analysis*. CRC Press.
+- Casella, G. & Berger, R. (2002). *Statistical Inference*. Duxbury.
+- Gelman, A. et al. (2013). *Bayesian Data Analysis*. CRC Press.
+- Glasserman, P. (2003). *Monte Carlo Methods in Financial Engineering*. Springer.
+- Robert, C. & Casella, G. (2004). *Monte Carlo Statistical Methods*. Springer.
 
 ---
 
-## How to Reproduce
-
-```bash
-git clone https://github.com/brunoramosmartins/monte-carlo-budget-article.git
-cd monte-carlo-budget-article
-python -m venv .venv && source .venv/bin/activate
-pip install -e ".[dev,notebook]"
-python scripts/exp_budget_simulation.py
-python scripts/exp_sensitivity.py
-pytest tests/
-```
-
-All figures are generated with fixed seeds for exact reproducibility.
+*All figures and numbers in this article are reproduced by versioned scripts with fixed seeds in the [companion repository](https://github.com/brunoramosmartins/monte-carlo-budget-article). See the repository README for how to run them.*

--- a/markdown_posts/probabilistic-cost-modelling.md
+++ b/markdown_posts/probabilistic-cost-modelling.md
@@ -8,41 +8,13 @@ tags: probability, distributions, heavy-tails, budgeting
 
 # The Shape of What You'll Spend
 
-## Probabilistic Modelling of People Costs — from Distribution Selection to Budget Impact
-
----
-
-## Executive Summary
-
-This article shows that the Normal distribution — the implicit default in most cost models — systematically underestimates tail risk in people-cost forecasting. Using Maximum Likelihood Estimation, information criteria (AIC/BIC), and goodness-of-fit tests, we derive a principled framework for distribution selection. The headline result: assuming Normal instead of Pareto for severance costs underestimates the probability of extreme expenses by a factor of **138x**, with direct implications for budget reserves.
-
----
-
-## What This Article Is
-
-This is a **practical statistical framework** for distribution selection in people-cost modelling. It is not a textbook on probability, nor a tutorial on Python. It assumes you accept that "the wrong distribution = the wrong budget" and want a rigorous, reproducible way to choose the right one.
-
-The article moves from theory (Sections 3–7) to experiments (Section 8) to a five-step decision framework (Section 9). The companion repository contains all code, synthetic data generators, and reproducible figures.
-
----
-
-## What You Need to Know
-
-This article assumes familiarity with:
-
-**Required:**
-- Calculus: derivatives, integrals, basic Taylor expansion
-- Basic probability: PDF, CDF, expectation, variance
-- Linear algebra: matrix inversion (used briefly for Fisher information)
-
-**Helpful but not required:**
-- Prior exposure to Maximum Likelihood Estimation (we derive it from first principles)
-- Familiarity with information criteria (AIC/BIC are derived in Section 5)
-
-**Out of scope (won't be covered):**
-- Bayesian inference and MCMC
-- Time-series and dependence modelling (briefly mentioned in Limitations)
-- Real-world data collection / NDA / privacy concerns
+> **What this is.** A practical framework for choosing probability distributions in people-cost modelling — and for pricing the cost of choosing wrong. The headline result: assuming a Normal instead of the Pareto that actually fits severance data underestimates the probability of extreme expenses by a factor of **138x**, with direct consequences for budget reserves. This is not a probability textbook or a Python tutorial: it assumes you accept that *the wrong distribution = the wrong budget* and want a rigorous, reproducible way to choose the right one.
+>
+> **What you should know before reading.** *Required:* calculus (derivatives, integrals, a basic Taylor expansion), basic probability (PDF, CDF, expectation, variance), and a little linear algebra (matrix inversion appears briefly for Fisher information). *Helpful but not required:* prior exposure to Maximum Likelihood Estimation and to information criteria — both are derived from first principles here. *Out of scope:* Bayesian inference and MCMC, time-series and dependence modelling, and real-world data collection concerns (NDA, privacy).
+>
+> **What you will take away.** A five-step decision procedure — visualise, fit, compare, validate, quantify — that you can apply to your own cost data, plus the vocabulary to defend the choice in front of a finance audience.
+>
+> **Code.** Every figure and number is reproduced by versioned scripts with fixed seeds in the [companion repository](https://github.com/brunoramosmartins/probabilistic-cost-modelling-article).
 
 ---
 
@@ -65,7 +37,7 @@ This article assumes familiarity with:
 
 ---
 
-## 1. Introduction: Why Distributions Matter
+## Why Distributions Matter
 
 A budget is a probability statement disguised as a spreadsheet. When an analyst projects people costs, they are implicitly assuming a probability distribution for each component — salaries, overtime, severance, hiring. In most organizations, that assumption is the Normal distribution: symmetric, light-tailed, well-behaved.
 
@@ -77,11 +49,11 @@ The problem is that people costs are not Normal. Salaries are right-skewed: most
 
 $$\text{Wrong distribution} \rightarrow \text{wrong parameters} \rightarrow \text{wrong budget} \rightarrow \text{wrong decisions}$$
 
-This article presents a rigorous framework for distribution selection in cost modelling. We derive Maximum Likelihood Estimation (MLE) from first principles, fit five candidate distribution families to synthetic cost data, and use information-theoretic criteria (AIC, BIC) and goodness-of-fit tests to select the best model. The companion article (Monte Carlo) shows how to use these distributions to simulate total team cost.
+This article presents a rigorous framework for distribution selection in cost modelling. We derive Maximum Likelihood Estimation (MLE) from first principles, fit five candidate distribution families to synthetic cost data, and use information-theoretic criteria (AIC, BIC) and goodness-of-fit tests to select the best model. The companion article [Why Your Budget Never Hits the Exact Number](monte-carlo-budget.html) shows how to use these distributions to simulate total team cost.
 
 ---
 
-## 2. What's at Stake
+## What's at Stake
 
 Before diving into the formalism, three numbers frame why the choice matters. The figure below previews the central comparison: under a Normal model, the budget reserve looks comfortable — until reality follows a Pareto.
 
@@ -99,7 +71,7 @@ The rest of the article shows how to detect, quantify, and correct each of these
 
 ---
 
-## 3. The Cost Components
+## The Cost Components
 
 To make the framework concrete, we need a model of what we're estimating. We represent each cost component as a random variable with distinct distributional properties. The model is generic, minimal, and expandable.
 
@@ -128,7 +100,7 @@ The expected total annual cost is approximately R\$ 6.0–6.5 million. The cruci
 
 ---
 
-## 4. Distribution Families
+## Distribution Families
 
 Now that we know which components we need to model, we need a vocabulary of candidate distributions that can capture their distinct shapes. For each component, we consider five distribution families. The Normal is included as the baseline to beat — not as a serious candidate.
 
@@ -159,9 +131,9 @@ Now that we know which components we need to model, we need a vocabulary of cand
 
 ---
 
-## 5. Maximum Likelihood Estimation
+## Maximum Likelihood Estimation
 
-We have candidate families. We now need a principled way to choose the *parameters* of each family from observed data. Maximum Likelihood Estimation (MLE) is the workhorse: it gives us optimal point estimates, automatic standard errors via Fisher information, and a foundation for the model comparison framework in Section 6.
+We have candidate families. We now need a principled way to choose the *parameters* of each family from observed data. Maximum Likelihood Estimation (MLE) is the workhorse: it gives us optimal point estimates, automatic standard errors via Fisher information, and a foundation for the [model comparison framework](#model-comparison) that comes next.
 
 ### The Estimation Problem
 
@@ -219,7 +191,7 @@ In practice: we report not just the parameter estimate but also its uncertainty 
 
 ---
 
-## 6. Model Comparison
+## Model Comparison
 
 We can now fit any candidate to data. But fitting alone doesn't tell us which family is the right one — and a model with more parameters will always fit training data better. The question becomes: how do we select between fitted models without rewarding complexity for its own sake?
 
@@ -276,7 +248,7 @@ Reject the restricted model if $\Lambda$ exceeds the critical value.
 
 ---
 
-## 7. Mixture Models and Multimodality
+## Mixture Models and Multimodality
 
 So far each component has been treated as a single distribution. But real salary data violates this assumption immediately: a single fit to a junior/senior team mixes two populations and produces a model that represents neither. Mixture models extend the framework to handle this directly.
 
@@ -316,7 +288,7 @@ We use BIC to select the number of components: fit GMMs with $K = 1, 2, 3, \ldot
 
 ### The Budget Cost of Ignoring Bimodality
 
-In Experiment D, ignoring bimodality and forcing a single Normal on a 60% junior / 40% senior mixture:
+In [Experiment D](#experiment-d-mixture-detection), ignoring bimodality and forcing a single Normal on a 60% junior / 40% senior mixture:
 - Inflates the estimated standard deviation by ~40%
 - Distorts VaR(95%) by R\$ 1,500–2,500 per employee
 - For a 50-person team, this is R\$ 75K–125K of misallocated reserve
@@ -327,7 +299,7 @@ In Experiment D, ignoring bimodality and forcing a single Normal on a 60% junior
 
 ---
 
-## 8. Heavy Tails and Extreme Costs
+## Heavy Tails and Extreme Costs
 
 Mixture models address the *center* of the distribution. But the most consequential modelling errors live in the *tails* — the rare-but-catastrophic events where budgets actually break. This section is the core of the article.
 
@@ -387,7 +359,7 @@ For the Pareto: $\text{ES}_p = \frac{\alpha}{\alpha - 1} \cdot \text{VaR}_p$ —
 
 ---
 
-## 9. Experiments and Results
+## Experiments and Results
 
 The theory above predicts specific consequences. This section tests those predictions through controlled experiments. Each experiment isolates one claim, runs it on synthetic data with known ground truth, and measures the gap between correct and incorrect modelling.
 
@@ -401,62 +373,83 @@ Every experiment in this article uses synthetic data generated from known distri
 
 This trades external validity (will it work on *your* HR system data?) for internal validity (does the framework do what it claims?). The companion repository documents how to apply the same pipeline to real data.
 
-### Experiment A: The Distribution Zoo
+### Experiment A — The Distribution Zoo
 
-- **Objective:** show how five candidate families adapt to the same right-skewed data.
-- **Setup:** $n = 2{,}000$ samples from LogNormal($\mu = 9.1$, $\sigma = 0.4$); fit Normal, LogNormal, Gamma, and Weibull via MLE.
-- **Metric:** visual overlay of fitted PDFs against the empirical histogram.
-- **Result:** LogNormal captures skewness perfectly; Normal misfits both peak and tail; Gamma and Weibull approximate but underestimate the right tail.
+**Claim.** Distribution families fitted to the same right-skewed data disagree most where it matters: the tail.
 
-### Experiment B: MLE Convergence
+**Setup.** $n = 2{,}000$ samples from LogNormal($\mu = 9.1$, $\sigma = 0.4$); Normal, LogNormal, Gamma, and Weibull fitted via MLE; fitted PDFs overlaid on the empirical histogram.
 
-- **Objective:** verify MLE consistency and asymptotic normality empirically.
-- **Setup:** 200 replications at each $n \in \{20, 50, 100, \ldots, 10{,}000\}$, fitting LogNormal($9.1, 0.4$).
-- **Metric:** mean and standard deviation of $\hat{\mu}$ across replications; comparison with theoretical SE = $\sigma / \sqrt{n}$.
-- **Result:** estimates converge to the true parameter; empirical SD matches theoretical $1/\sqrt{n}$ decay across three orders of magnitude.
+**Result.** LogNormal captures the skewness; Normal misfits both peak and tail; Gamma and Weibull approximate the bulk but underestimate the right tail.
 
-### Experiment C: The Cost of the Wrong Distribution
+**Connection.** Confirms the shape vocabulary of [Distribution Families](#distribution-families): support and tail behaviour, not the mean, are what separate the candidates.
 
-- **Objective:** quantify the budget error from fitting Normal to LogNormal data.
-- **Setup:** generate $n = 1{,}000$ from LogNormal; fit Normal and LogNormal; simulate 200K samples from each fitted model.
-- **Metric:** $P(\text{cost} > \text{ceiling})$ at multiples of the mean; VaR(99%) and ES(99%) gap.
-- **Result:** Normal underestimates $P(X > 2 \cdot \text{mean})$ by ~3x and $P(X > 3 \cdot \text{mean})$ by ~8x. For a 50-person team, this translates to R\$ 100K–150K of insufficient reserve.
+### Experiment B — MLE Convergence
+
+**Claim.** MLE is consistent and its error decays as $1/\sqrt{n}$, exactly as the asymptotic theory predicts.
+
+**Setup.** 200 replications at each $n \in \{20, 50, 100, \ldots, 10{,}000\}$, fitting LogNormal($9.1, 0.4$); empirical mean and standard deviation of $\hat{\mu}$ compared with the theoretical SE $= \sigma / \sqrt{n}$.
+
+**Result.** Estimates converge to the true parameter; the empirical SD matches the theoretical $1/\sqrt{n}$ decay across three orders of magnitude.
+
+**Connection.** Empirical confirmation of the asymptotic normality result in [Maximum Likelihood Estimation](#maximum-likelihood-estimation).
+
+### Experiment C — The Cost of the Wrong Distribution
+
+**Claim.** Fitting a Normal to LogNormal cost data systematically underestimates tail probabilities — and therefore the reserve.
+
+**Setup.** $n = 1{,}000$ generated from LogNormal; Normal and LogNormal fitted; 200K samples simulated from each fitted model; $P(\text{cost} > \text{ceiling})$ at multiples of the mean, plus VaR(99%) and ES(99%), compared.
+
+**Result.** Normal underestimates $P(X > 2 \cdot \text{mean})$ by ~3x and $P(X > 3 \cdot \text{mean})$ by ~8x. For a 50-person team, this translates to R\$ 100K–150K of insufficient reserve.
+
+**Connection.** Puts numbers on the salary-component gap promised in [What's at Stake](#whats-at-stake).
 
 ![Impact of the wrong distribution on budget](../figures/probabilistic-cost-modelling/wrong_distribution_impact.png)
 
-### Experiment D: Mixture Detection
+### Experiment D — Mixture Detection
 
-- **Objective:** show that GMM with BIC selection recovers hidden bimodal structure.
-- **Setup:** 60% sampled from $N(8000, 1500^2)$, 40% from $N(18000, 2500^2)$; fit GMMs with $K \in \{1, 2, 3, 4\}$.
-- **Metric:** BIC across $K$; recovered weights, means, and standard deviations.
-- **Result:** BIC strongly favors $K = 2$. Recovered parameters are within 5% of true values. Single-Normal fit produces a mean that represents no actual employee.
+**Claim.** GMM with BIC selection recovers hidden bimodal structure that any single-family fit misses.
 
-### Experiment E: Heavy Tail Risk
+**Setup.** 60% sampled from $N(8000, 1500^2)$, 40% from $N(18000, 2500^2)$; GMMs fitted with $K \in \{1, 2, 3, 4\}$; BIC compared across $K$; recovered weights, means, and standard deviations inspected.
 
-- **Objective:** measure the tail-probability gap between Pareto and Normal at the same first two moments.
-- **Setup:** Pareto($\alpha = 2.5$, $x_m = 10{,}000$) vs moment-matched Normal at $\mu = 16{,}667$, $\sigma = 14{,}907$.
-- **Metric:** $P(X > x)$ at thresholds R\$ 30K to R\$ 200K; analytical VaR and ES at 90%, 95%, 99%.
-- **Result:** Normal underestimates $P(X > 50K)$ by 138x, and ES(99%) by ~1.9x. The "rare event" under Normal is a routine one under Pareto.
+**Result.** BIC strongly favors $K = 2$. Recovered parameters are within 5% of true values. The single-Normal fit produces a mean that represents no actual employee.
 
-### Experiment F: Model Comparison
+**Connection.** Validates the EM + BIC procedure of [Mixture Models and Multimodality](#mixture-models-and-multimodality).
 
-- **Objective:** validate that AIC, BIC, and KS jointly identify the true distribution.
-- **Setup:** $n = 500$ from LogNormal; fit all five candidates; compute information criteria and goodness-of-fit tests.
-- **Metric:** Akaike weights, BIC ranking, KS p-values.
-- **Result:** LogNormal wins with Akaike weight > 96%. Normal is decisively rejected. KS test confirms LogNormal is the only candidate that passes goodness-of-fit.
+### Experiment E — Heavy Tail Risk
 
-### Experiment G: End-to-End Pipeline
+**Claim.** At matched mean and variance, Pareto and Normal disagree by orders of magnitude in the tail.
 
-- **Objective:** demonstrate the full workflow on a synthetic 50-person team.
-- **Setup:** generate salary, overtime, severance, and hiring data; fit all candidates to each component; rank via AIC/BIC; compute budget impact.
-- **Metric:** automatic best-model selection per component; resulting VaR and reserve.
-- **Result:** pipeline correctly identifies LogNormal for salary and Pareto for severance. Total reserve at 99% differs by R\$ 100K–150K from the Normal-baseline estimate.
+**Setup.** Pareto($\alpha = 2.5$, $x_m = 10{,}000$) vs moment-matched Normal at $\mu = 16{,}667$, $\sigma = 14{,}907$; $P(X > x)$ at thresholds R\$ 30K to R\$ 200K; analytical VaR and ES at 90%, 95%, 99%.
+
+**Result.** Normal underestimates $P(X > 50K)$ by 138x, and ES(99%) by ~1.9x. The "rare event" under Normal is a routine one under Pareto — the headline gap of this article.
+
+**Connection.** The polynomial-vs-exponential tail decay derived in [Heavy Tails and Extreme Costs](#heavy-tails-and-extreme-costs), made numerical.
+
+### Experiment F — Model Comparison
+
+**Claim.** AIC, BIC, and goodness-of-fit tests jointly identify the true distribution.
+
+**Setup.** $n = 500$ from LogNormal; all five candidates fitted; Akaike weights, BIC ranking, and KS p-values computed.
+
+**Result.** LogNormal wins with Akaike weight > 96%. Normal is decisively rejected. The KS test confirms LogNormal is the only candidate that passes goodness-of-fit.
+
+**Connection.** The selection machinery of [Model Comparison](#model-comparison) working end to end on data with known ground truth.
+
+### Experiment G — End-to-End Pipeline
+
+**Claim.** The full workflow selects the right family per component and prices the budget impact automatically.
+
+**Setup.** Synthetic 50-person team (salary, overtime, severance, and hiring data); all candidates fitted to each component; ranking via AIC/BIC; resulting VaR and reserve computed.
+
+**Result.** The pipeline correctly identifies LogNormal for salary and Pareto for severance. The total reserve at 99% differs by R\$ 100K–150K from the Normal-baseline estimate.
+
+**Connection.** A dry run of the five-step procedure condensed in [A Practical Framework](#a-practical-framework).
 
 ![End-to-end pipeline: data → fit → select → budget impact](../figures/probabilistic-cost-modelling/full_pipeline.png)
 
 ---
 
-## 10. Practical Framework
+## A Practical Framework
 
 The theory and experiments above point to a concrete decision procedure. This section condenses everything into a five-step workflow that any analyst can apply to their own data.
 
@@ -507,7 +500,7 @@ This five-step path covers most real cost-modelling decisions. The full framewor
 
 ---
 
-## 11. Limitations
+## Limitations
 
 The framework above is deliberately scoped. The following limitations are not failures of the method — they are boundaries within which it operates.
 
@@ -515,7 +508,7 @@ The framework above is deliberately scoped. The following limitations are not fa
 
 **Model risk persists.** Choosing the best of five candidates does not guarantee any of them is correct. Goodness-of-fit tests guard against gross misspecification but cannot detect a sixth, unconsidered family. The framework reduces model risk; it does not eliminate it.
 
-**Independence assumption.** Each cost component is modelled independently. In reality, components are correlated: a wave of layoffs simultaneously reduces hiring costs and inflates severance. Modelling these dependencies requires multivariate methods (copulas, joint distributions) covered in the companion Monte Carlo article.
+**Independence assumption.** Each cost component is modelled independently. In reality, components are correlated: a wave of layoffs simultaneously reduces hiring costs and inflates severance. Modelling these dependencies requires multivariate methods (copulas, joint distributions) covered in the companion article [Why Your Budget Never Hits the Exact Number](monte-carlo-budget.html).
 
 **Static distributions.** This article assumes distributions are stable over time. Salary distributions drift with inflation, market shifts, and organizational changes. Time-series methods (state-space models, regime-switching) are out of scope.
 
@@ -525,7 +518,7 @@ The framework above is deliberately scoped. The following limitations are not fa
 
 ---
 
-## 12. Conclusion
+## Conclusion
 
 ### The Distribution Is the Model
 
@@ -541,9 +534,7 @@ The distributional assumption is not a technical detail — it is the most impor
 
 ### Next Steps
 
-This article establishes the distributional selection framework. The companion article (Monte Carlo) shows how to use these distributions to simulate total team cost, including correlations between components and scenario analysis.
-
-The complete code is available in the associated repository, with reproducible synthetic data and publication-quality figures.
+This article establishes the distributional selection framework. The companion article [Why Your Budget Never Hits the Exact Number](monte-carlo-budget.html) shows how to use these distributions to simulate total team cost, including correlations between components and scenario analysis.
 
 ---
 
@@ -554,3 +545,7 @@ The complete code is available in the associated repository, with reproducible s
 - Bishop, C. (2006). *Pattern Recognition and Machine Learning*. Springer.
 - Embrechts, P., Klüppelberg, C. & Mikosch, T. (1997). *Modelling Extremal Events*. Springer.
 - McLachlan, G. & Peel, D. (2000). *Finite Mixture Models*. Wiley.
+
+---
+
+*All figures and numbers in this article are reproduced by versioned scripts with fixed seeds in the [companion repository](https://github.com/brunoramosmartins/probabilistic-cost-modelling-article). See the repository README for how to run them.*

--- a/posts/krippendorff-alpha.html
+++ b/posts/krippendorff-alpha.html
@@ -314,7 +314,7 @@ $$</p>
 P(\text{agree}) = \sum_{k=1}^K \Bigl(\frac{n_k}{N}\Bigr)^2.
 $$</p>
 <p>This quantity coincides with the pairwise-within-item $A_o$ in simple balanced designs but <strong>diverges</strong> when the number of raters varies by item or missingness is uneven. It remains useful as an intuitive "overall overlap" index and matches the $\sum_k p_k^2$ algebra that reappears in Fleiss' expected agreement $\bar P_e$. The companion code implements both variants so experiments can be checked against the definition you standardise in your protocol.</p>
-<h3 id="24-what-mathinline6e9f31f111ad4ed5898779508b57ccbf-estimates-and-what-it-misses">2.4 What $A_o$ estimates — and what it misses</h3>
+<h3 id="24-what-mathinlineb01004e0ccf8407eae24792a7a3ff73d-estimates-and-what-it-misses">2.4 What $A_o$ estimates — and what it misses</h3>
 <p>$A_o$ is a transparent <strong>descriptive</strong> statistic. What it is <strong>not</strong> is a calibrated measure of "how much better than chance" the panel behaves. Two independent annotators who each draw labels from a skewed distribution $\pi$ will still agree with probability $\sum_k \pi_k^2$, often far above zero. If your reported $A_o$ is close to that quantity, the data are compatible with <strong>independence</strong>, not with a shared latent truth.</p>
 <p>Like any binomial-style proportion, $A_o$ has <strong>sampling variability</strong>. Wide items and sparse rare classes can make point estimates noisy; the experiments in Section 8 use $n = 10\,000$ items partly to make curves visually stable. In applied work, complement point estimates with <strong>confidence intervals</strong> (bootstrap over items is common) and with <strong>disaggregated</strong> views (per-stratum agreement, confusion matrices).</p>
 <p>Hence the framing: treat $A_o$ as an <strong>estimator</strong> of overlap under your sampling scheme, and always ask what <strong>benchmark</strong> it should be compared to.</p>
@@ -363,10 +363,10 @@ $$</p>
 </tbody>
 </table>
 <p>The third row is the <strong>warning shot</strong> for applied reports: <strong>more than half</strong> of independent draws would already match even though three categories exist.</p>
-<h3 id="32-random-annotators-why-mathinline0e7a9cd1f9684da9a1beb6b705d450f1-does-not-go-to-zero">3.2 Random annotators: why $A_o$ does not go to zero</h3>
+<h3 id="32-random-annotators-why-mathinline4bce663e368f4ef7a84d434cdd7f1021-does-not-go-to-zero">3.2 Random annotators: why $A_o$ does not go to zero</h3>
 <p>Suppose every matrix entry is drawn <strong>independently</strong> from $\pi$ (no shared latent item truth). Then two ratings on the same item are independent draws from $\pi$, and the probability they agree is <strong>exactly</strong> $A_e = \sum_k \pi_k^2 > 0$ for any non-degenerate $\pi$.</p>
 <p>So <strong>"random" does not mean "zero agreement"</strong>; it means agreement at the <strong>chance</strong> level implied by the marginals. Any headline that cites $A_o$ without that context risks overstating reliability.</p>
-<h3 id="33-empirical-check-convergence-to-mathinline3c1e7c1349534befb8a3cd551121668a">3.3 Empirical check: convergence to $\sum_k \pi_k^2$</h3>
+<h3 id="33-empirical-check-convergence-to-mathinline97e16dc15e5c420b912ccd441becf7be">3.3 Empirical check: convergence to $\sum_k \pi_k^2$</h3>
 <p>The companion codebase simulates Model 1 annotators and tracks $A_o$ as item count grows. The simulation matches theory: empirical agreement concentrates on $\sum_k \pi_k^2$. If real data looked like this, the annotation process would carry no item-specific signal. Real studies usually violate that assumption — which is why we need coefficients that separate structured agreement from prevalence-driven overlap.</p>
 <figure><img src="../figures/krippendorff-alpha/random_agreement_convergence.png" alt="Simulated convergence of observed agreement to the independence baseline under i.i.d. random labelling." loading="lazy"><figcaption>Simulated convergence of observed agreement to the independence baseline under i.i.d. random labelling.</figcaption></figure>
 <p><strong>Figure 1.</strong> Random i.i.d. annotators: empirical observed agreement approaches the theoretical expected agreement $A_e = \sum_k \pi_k^2$ as sample size increases.</p>
@@ -385,7 +385,7 @@ $$</p>
 <li>$\kappa < 0$ if $A_o < A_e$ (worse than the baseline).</li>
 </ul>
 <p>Different coefficients differ in how $A_o$ and $A_e$ are operationalised. The denominator $1-A_e$ rescales the excess agreement so that $\kappa$ lives on a <strong>comparable</strong> scale across tasks with different baselines: the same raw gap $A_o - A_e$ means more when chance agreement was already rare than when it was ubiquitous. That rescaling is intellectually satisfying but also explains why $\kappa$ can swing dramatically when <strong>small changes</strong> in rare-class counts move $A_e$: the coefficient is <strong>ratio-based</strong>, not variance-stabilised.</p>
-<h3 id="42-cohens-mathinline440b31d1323d4c9590d8b08b4e3f3186-two-fixed-raters">4.2 Cohen's $\kappa$ (two fixed raters)</h3>
+<h3 id="42-cohens-mathinline862dfdfe17b04f60a0862be1da52976b-two-fixed-raters">4.2 Cohen's $\kappa$ (two fixed raters)</h3>
 <p>Two annotators rate the same $n$ items: $X_{i1}, X_{i2} \in \{1,\ldots,K\}$.</p>
 <p><strong>Observed agreement:</strong></p>
 <p>$$
@@ -398,7 +398,7 @@ $$</p>
 <p><strong>Cohen's kappa:</strong> $\kappa_C = (A_o - A_e)/(1-A_e)$.</p>
 <p><strong>Worked $2\times 2$ example (three items).</strong> With encodings A/B giving $A_o = 2/3$ and marginals $(2/3, 1/3)$ vs $(1/3, 2/3)$, one obtains $A_e = 4/9$ and $\kappa_C = 0.4$.</p>
 <p>Cohen's $\kappa$ is <strong>symmetric</strong> in the two raters for this definition and is widely implemented (e.g. scikit-learn). Its weakness for modern annotation is structural: <strong>only two</strong> fixed individuals, no native slot for "sometimes three crowd workers, sometimes two," and ad hoc handling of missing pairs by <strong>dropping</strong> items. Those limitations are acceptable in classic test–retest studies; they bite in crowdsourcing and LLM–human panels.</p>
-<h3 id="43-fleiss-mathinline51297cc2645846beb033874845fb73ab-several-raters-per-item">4.3 Fleiss' $\kappa$ (several raters per item)</h3>
+<h3 id="43-fleiss-mathinline0bcce7c7d9304e54afc27e732ee5c156-several-raters-per-item">4.3 Fleiss' $\kappa$ (several raters per item)</h3>
 <p>There are $n$ items and $m$ raters per item (balanced design). For item $i$, let $n_{ik}$ be the count of raters who chose category $k$ ($\sum_k n_{ik} = m$).</p>
 <p><strong>Extent of agreement on item $i$:</strong></p>
 <p>$$
@@ -448,7 +448,7 @@ $$</p>
 </tbody>
 </table>
 <p>Ordinal, interval, and ratio data can be squeezed into nominal bins or <strong>weighted</strong> $\kappa$, but there is no single Kappa object that natively carries <strong>metric</strong> distances between categories while handling <strong>variable</strong> numbers of judgments and <strong>missing</strong> cells in one framework.</p>
-<h3 id="53-building-the-case-for-mathinlinee899038205214f3ab1300ee17b5c69b9">5.3 Building the case for $\alpha$</h3>
+<h3 id="53-building-the-case-for-mathinlinee756547635914a86855a5bb1d1e8607e">5.3 Building the case for $\alpha$</h3>
 <p>We need a coefficient that:</p>
 <ol>
 <li>Compares observed <strong>disagreement</strong> to a <strong>chance</strong> level of disagreement under a clear random pairing model.</li>
@@ -549,7 +549,7 @@ $$</p>
 \alpha = 1 - \frac{D_o^*}{D_e^*}.
 $$</p>
 <p>When $D_e^*$ is zero (degenerate case), $\alpha$ is not defined as a finite ratio.</p>
-<h3 id="72-building-mathinlinefe38f18e3b39489eba4473fb8309d85c-sketch">7.2 Building $\mathbf{O}$ (sketch)</h3>
+<h3 id="72-building-mathinline4f846bafbb81497db01b971817f69aee-sketch">7.2 Building $\mathbf{O}$ (sketch)</h3>
 <p>For each unit $i$ with $m_i \ge 2$ observed judgments, form the count vector $\mathbf{n}_i = (n_{i1},\ldots,n_{iV})$ of how many raters used each domain value. Unnormalised co-occurrence is related to $\mathbf{n}_i\mathbf{n}_i^\top$ with the diagonal adjusted so self-pairs from the <strong>same</strong> rater do not count. Scale by $1/(m_i-1)$ and sum over units. <strong>Missing</strong> raters are dropped before forming $\mathbf{n}_i$; no pair is formed with a missing cell.</p>
 <p>Concretely, for a single unit with three raters and counts $(2,1,0)$ on domain $(v_1,v_2,v_3)$, the adjustment subtracts rater self-pairs from the outer product of counts, then divides by $m_i-1$. The resulting local matrix contributes off-diagonal mass where <strong>cross-category</strong> pairings occur; the diagonal records <strong>within-category</strong> pairings that survive the subtraction. Summing these contributions over <strong>all</strong> units yields $\mathbf{O}$. The implementation in the repository follows Krippendorff (2004) and is cross-checked against the <code>krippendorff</code> Python package on reference reliability matrices.</p>
 <h3 id="73-expected-coincidence">7.3 Expected coincidence</h3>
@@ -577,7 +577,7 @@ $$</p>
 \alpha = \frac{D_e^* - D_o^*}{D_e^*}.
 $$</p>
 <p>So $\alpha$ is the <strong>fractional reduction</strong> of observed disagreement relative to the expected matrix under the null — analogous in spirit to how $\kappa$ expresses excess agreement relative to $1-A_e$, but built on <strong>metric</strong> weights rather than a single scalar $A_o$. Negative $\alpha$ means the pattern of weighted distances is <strong>more discordant</strong> than random pairing would predict under fixed exposure, a warning sign of <strong>systematic</strong> divergence (ambiguous guidelines, adversarial items, or instrument drift).</p>
-<h3 id="76-relation-to-cohens-mathinline08334073a4b2450bad5b90b06d1ca446">7.6 Relation to Cohen's $\kappa$</h3>
+<h3 id="76-relation-to-cohens-mathinline596040ba74824f178d94bcd6ad8a9fb8">7.6 Relation to Cohen's $\kappa$</h3>
 <p>Cohen's $\kappa$ uses <strong>per-rater</strong> marginals on the same items. Krippendorff's $\alpha$ uses <strong>pooled</strong> coincidence marginals from $\mathbf{O}$. For <strong>two</strong> raters and <strong>nominal</strong> data, both correct for chance, but the <strong>numerical value</strong> need not equal $\kappa_C$ when $K>2$: the chance models differ. In practice, report <strong>one</strong> coefficient and stick to its interpretation, or compare both explicitly in a sensitivity table.</p>
 <h3 id="77-software-and-reproducibility">7.7 Software and reproducibility</h3>
 <p>The article's claims about $\alpha$ are backed by <code>krippendorff_alpha()</code> in the companion package, validated against published examples and the reference library. <strong>Nominal</strong>, <strong>interval</strong>, <strong>ratio</strong>, and <strong>ordinal</strong> levels are implemented with explicit <strong>value domains</strong> so that unused categories do not distort distances. When you port formulas into another language, the fragile details are usually the <strong>ordinal</strong> weights and the treatment of <strong>all-missing</strong> units — test against the reference package before trusting edge cases.</p>

--- a/posts/krippendorff-alpha.html
+++ b/posts/krippendorff-alpha.html
@@ -179,8 +179,9 @@
 
     .article-toc__inner {
       position: sticky;
-      top: var(--space-8);
-      max-height: calc(100vh - var(--space-16));
+      /* clear the fixed site header, plus breathing room */
+      top: calc(var(--header-height) + var(--space-6));
+      max-height: calc(100vh - var(--header-height) - var(--space-12));
       overflow-y: auto;
       padding-left: var(--space-4);
       border-left: 1px solid var(--color-border);
@@ -313,7 +314,7 @@ $$</p>
 P(\text{agree}) = \sum_{k=1}^K \Bigl(\frac{n_k}{N}\Bigr)^2.
 $$</p>
 <p>This quantity coincides with the pairwise-within-item $A_o$ in simple balanced designs but <strong>diverges</strong> when the number of raters varies by item or missingness is uneven. It remains useful as an intuitive "overall overlap" index and matches the $\sum_k p_k^2$ algebra that reappears in Fleiss' expected agreement $\bar P_e$. The companion code implements both variants so experiments can be checked against the definition you standardise in your protocol.</p>
-<h3 id="24-what-mathinline9392af733385481399a23d9107ac71ef-estimates-and-what-it-misses">2.4 What $A_o$ estimates — and what it misses</h3>
+<h3 id="24-what-mathinline6e9f31f111ad4ed5898779508b57ccbf-estimates-and-what-it-misses">2.4 What $A_o$ estimates — and what it misses</h3>
 <p>$A_o$ is a transparent <strong>descriptive</strong> statistic. What it is <strong>not</strong> is a calibrated measure of "how much better than chance" the panel behaves. Two independent annotators who each draw labels from a skewed distribution $\pi$ will still agree with probability $\sum_k \pi_k^2$, often far above zero. If your reported $A_o$ is close to that quantity, the data are compatible with <strong>independence</strong>, not with a shared latent truth.</p>
 <p>Like any binomial-style proportion, $A_o$ has <strong>sampling variability</strong>. Wide items and sparse rare classes can make point estimates noisy; the experiments in Section 8 use $n = 10\,000$ items partly to make curves visually stable. In applied work, complement point estimates with <strong>confidence intervals</strong> (bootstrap over items is common) and with <strong>disaggregated</strong> views (per-stratum agreement, confusion matrices).</p>
 <p>Hence the framing: treat $A_o$ as an <strong>estimator</strong> of overlap under your sampling scheme, and always ask what <strong>benchmark</strong> it should be compared to.</p>
@@ -362,10 +363,10 @@ $$</p>
 </tbody>
 </table>
 <p>The third row is the <strong>warning shot</strong> for applied reports: <strong>more than half</strong> of independent draws would already match even though three categories exist.</p>
-<h3 id="32-random-annotators-why-mathinlinef5444110ff7d4c03b394f110f76d6b4a-does-not-go-to-zero">3.2 Random annotators: why $A_o$ does not go to zero</h3>
+<h3 id="32-random-annotators-why-mathinline0e7a9cd1f9684da9a1beb6b705d450f1-does-not-go-to-zero">3.2 Random annotators: why $A_o$ does not go to zero</h3>
 <p>Suppose every matrix entry is drawn <strong>independently</strong> from $\pi$ (no shared latent item truth). Then two ratings on the same item are independent draws from $\pi$, and the probability they agree is <strong>exactly</strong> $A_e = \sum_k \pi_k^2 > 0$ for any non-degenerate $\pi$.</p>
 <p>So <strong>"random" does not mean "zero agreement"</strong>; it means agreement at the <strong>chance</strong> level implied by the marginals. Any headline that cites $A_o$ without that context risks overstating reliability.</p>
-<h3 id="33-empirical-check-convergence-to-mathinline723603c532c44dd69b37fd0225cffad8">3.3 Empirical check: convergence to $\sum_k \pi_k^2$</h3>
+<h3 id="33-empirical-check-convergence-to-mathinline3c1e7c1349534befb8a3cd551121668a">3.3 Empirical check: convergence to $\sum_k \pi_k^2$</h3>
 <p>The companion codebase simulates Model 1 annotators and tracks $A_o$ as item count grows. The simulation matches theory: empirical agreement concentrates on $\sum_k \pi_k^2$. If real data looked like this, the annotation process would carry no item-specific signal. Real studies usually violate that assumption — which is why we need coefficients that separate structured agreement from prevalence-driven overlap.</p>
 <figure><img src="../figures/krippendorff-alpha/random_agreement_convergence.png" alt="Simulated convergence of observed agreement to the independence baseline under i.i.d. random labelling." loading="lazy"><figcaption>Simulated convergence of observed agreement to the independence baseline under i.i.d. random labelling.</figcaption></figure>
 <p><strong>Figure 1.</strong> Random i.i.d. annotators: empirical observed agreement approaches the theoretical expected agreement $A_e = \sum_k \pi_k^2$ as sample size increases.</p>
@@ -384,7 +385,7 @@ $$</p>
 <li>$\kappa < 0$ if $A_o < A_e$ (worse than the baseline).</li>
 </ul>
 <p>Different coefficients differ in how $A_o$ and $A_e$ are operationalised. The denominator $1-A_e$ rescales the excess agreement so that $\kappa$ lives on a <strong>comparable</strong> scale across tasks with different baselines: the same raw gap $A_o - A_e$ means more when chance agreement was already rare than when it was ubiquitous. That rescaling is intellectually satisfying but also explains why $\kappa$ can swing dramatically when <strong>small changes</strong> in rare-class counts move $A_e$: the coefficient is <strong>ratio-based</strong>, not variance-stabilised.</p>
-<h3 id="42-cohens-mathinline441b1272668647f99c67fcf08501a1b6-two-fixed-raters">4.2 Cohen's $\kappa$ (two fixed raters)</h3>
+<h3 id="42-cohens-mathinline440b31d1323d4c9590d8b08b4e3f3186-two-fixed-raters">4.2 Cohen's $\kappa$ (two fixed raters)</h3>
 <p>Two annotators rate the same $n$ items: $X_{i1}, X_{i2} \in \{1,\ldots,K\}$.</p>
 <p><strong>Observed agreement:</strong></p>
 <p>$$
@@ -397,7 +398,7 @@ $$</p>
 <p><strong>Cohen's kappa:</strong> $\kappa_C = (A_o - A_e)/(1-A_e)$.</p>
 <p><strong>Worked $2\times 2$ example (three items).</strong> With encodings A/B giving $A_o = 2/3$ and marginals $(2/3, 1/3)$ vs $(1/3, 2/3)$, one obtains $A_e = 4/9$ and $\kappa_C = 0.4$.</p>
 <p>Cohen's $\kappa$ is <strong>symmetric</strong> in the two raters for this definition and is widely implemented (e.g. scikit-learn). Its weakness for modern annotation is structural: <strong>only two</strong> fixed individuals, no native slot for "sometimes three crowd workers, sometimes two," and ad hoc handling of missing pairs by <strong>dropping</strong> items. Those limitations are acceptable in classic test–retest studies; they bite in crowdsourcing and LLM–human panels.</p>
-<h3 id="43-fleiss-mathinline46fd6ac71036458b92a30e159e48d8d6-several-raters-per-item">4.3 Fleiss' $\kappa$ (several raters per item)</h3>
+<h3 id="43-fleiss-mathinline51297cc2645846beb033874845fb73ab-several-raters-per-item">4.3 Fleiss' $\kappa$ (several raters per item)</h3>
 <p>There are $n$ items and $m$ raters per item (balanced design). For item $i$, let $n_{ik}$ be the count of raters who chose category $k$ ($\sum_k n_{ik} = m$).</p>
 <p><strong>Extent of agreement on item $i$:</strong></p>
 <p>$$
@@ -447,7 +448,7 @@ $$</p>
 </tbody>
 </table>
 <p>Ordinal, interval, and ratio data can be squeezed into nominal bins or <strong>weighted</strong> $\kappa$, but there is no single Kappa object that natively carries <strong>metric</strong> distances between categories while handling <strong>variable</strong> numbers of judgments and <strong>missing</strong> cells in one framework.</p>
-<h3 id="53-building-the-case-for-mathinlinee4cac1537a054a09ad0d80aae22c2e08">5.3 Building the case for $\alpha$</h3>
+<h3 id="53-building-the-case-for-mathinlinee899038205214f3ab1300ee17b5c69b9">5.3 Building the case for $\alpha$</h3>
 <p>We need a coefficient that:</p>
 <ol>
 <li>Compares observed <strong>disagreement</strong> to a <strong>chance</strong> level of disagreement under a clear random pairing model.</li>
@@ -548,7 +549,7 @@ $$</p>
 \alpha = 1 - \frac{D_o^*}{D_e^*}.
 $$</p>
 <p>When $D_e^*$ is zero (degenerate case), $\alpha$ is not defined as a finite ratio.</p>
-<h3 id="72-building-mathinline890d975b09814efabc6c03e0ed7ff03e-sketch">7.2 Building $\mathbf{O}$ (sketch)</h3>
+<h3 id="72-building-mathinlinefe38f18e3b39489eba4473fb8309d85c-sketch">7.2 Building $\mathbf{O}$ (sketch)</h3>
 <p>For each unit $i$ with $m_i \ge 2$ observed judgments, form the count vector $\mathbf{n}_i = (n_{i1},\ldots,n_{iV})$ of how many raters used each domain value. Unnormalised co-occurrence is related to $\mathbf{n}_i\mathbf{n}_i^\top$ with the diagonal adjusted so self-pairs from the <strong>same</strong> rater do not count. Scale by $1/(m_i-1)$ and sum over units. <strong>Missing</strong> raters are dropped before forming $\mathbf{n}_i$; no pair is formed with a missing cell.</p>
 <p>Concretely, for a single unit with three raters and counts $(2,1,0)$ on domain $(v_1,v_2,v_3)$, the adjustment subtracts rater self-pairs from the outer product of counts, then divides by $m_i-1$. The resulting local matrix contributes off-diagonal mass where <strong>cross-category</strong> pairings occur; the diagonal records <strong>within-category</strong> pairings that survive the subtraction. Summing these contributions over <strong>all</strong> units yields $\mathbf{O}$. The implementation in the repository follows Krippendorff (2004) and is cross-checked against the <code>krippendorff</code> Python package on reference reliability matrices.</p>
 <h3 id="73-expected-coincidence">7.3 Expected coincidence</h3>
@@ -576,7 +577,7 @@ $$</p>
 \alpha = \frac{D_e^* - D_o^*}{D_e^*}.
 $$</p>
 <p>So $\alpha$ is the <strong>fractional reduction</strong> of observed disagreement relative to the expected matrix under the null — analogous in spirit to how $\kappa$ expresses excess agreement relative to $1-A_e$, but built on <strong>metric</strong> weights rather than a single scalar $A_o$. Negative $\alpha$ means the pattern of weighted distances is <strong>more discordant</strong> than random pairing would predict under fixed exposure, a warning sign of <strong>systematic</strong> divergence (ambiguous guidelines, adversarial items, or instrument drift).</p>
-<h3 id="76-relation-to-cohens-mathinlinea38ff713aa104c10bf36e39e910c28e2">7.6 Relation to Cohen's $\kappa$</h3>
+<h3 id="76-relation-to-cohens-mathinline08334073a4b2450bad5b90b06d1ca446">7.6 Relation to Cohen's $\kappa$</h3>
 <p>Cohen's $\kappa$ uses <strong>per-rater</strong> marginals on the same items. Krippendorff's $\alpha$ uses <strong>pooled</strong> coincidence marginals from $\mathbf{O}$. For <strong>two</strong> raters and <strong>nominal</strong> data, both correct for chance, but the <strong>numerical value</strong> need not equal $\kappa_C$ when $K>2$: the chance models differ. In practice, report <strong>one</strong> coefficient and stick to its interpretation, or compare both explicitly in a sensitivity table.</p>
 <h3 id="77-software-and-reproducibility">7.7 Software and reproducibility</h3>
 <p>The article's claims about $\alpha$ are backed by <code>krippendorff_alpha()</code> in the companion package, validated against published examples and the reference library. <strong>Nominal</strong>, <strong>interval</strong>, <strong>ratio</strong>, and <strong>ordinal</strong> levels are implemented with explicit <strong>value domains</strong> so that unused categories do not distort distances. When you port formulas into another language, the fragile details are usually the <strong>ordinal</strong> weights and the treatment of <strong>all-missing</strong> units — test against the reference package before trusting edge cases.</p>

--- a/posts/monte-carlo-budget.html
+++ b/posts/monte-carlo-budget.html
@@ -1,0 +1,1114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Monte Carlo simulation for budget planning — from point estimates to probability distributions." />
+  <title>Why Your Budget Never Hits the Exact Number — Bruno Ramos Martins</title>
+
+  <!-- Favicon -->
+  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg" />
+
+  <!-- Open Graph -->
+  <meta property="og:type"        content="article" />
+  <meta property="og:title"       content="Why Your Budget Never Hits the Exact Number — Bruno Ramos Martins" />
+  <meta property="og:description" content="Monte Carlo simulation for budget planning — from point estimates to probability distributions." />
+  <meta property="og:url"         content="https://brunoramosmartins.github.io/posts/monte-carlo-budget.html" />
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&family=IBM+Plex+Serif:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&display=swap" rel="stylesheet" />
+
+  <!-- MathJax — renders LaTeX math ($...$, $$...$$) -->
+  <script>
+    MathJax = {
+      tex: {
+        inlineMath:  [['$', '$']],
+        displayMath: [['$$', '$$']],
+      },
+    };
+  </script>
+  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
+
+  <!-- Styles -->
+  <link rel="stylesheet" href="../assets/css/base.css" />
+  <link rel="stylesheet" href="../assets/css/layout.css" />
+  <link rel="stylesheet" href="../assets/css/components.css" />
+  <link rel="stylesheet" href="../assets/css/highlight.css" />
+
+  <style>
+    /* === Article-specific prose styles === */
+    .article-prose {
+      max-width: var(--container-max);
+      margin: 0 auto;
+    }
+
+    .article-prose h2 {
+      font-size: var(--text-3xl);
+      font-weight: var(--weight-bold);
+      letter-spacing: -0.02em;
+      margin-top: var(--space-16);
+      margin-bottom: var(--space-4);
+      padding-bottom: var(--space-3);
+      border-bottom: 1px solid var(--color-border);
+    }
+
+    .article-prose h3 {
+      font-size: var(--text-2xl);
+      font-weight: var(--weight-semibold);
+      letter-spacing: -0.01em;
+      margin-top: var(--space-10);
+      margin-bottom: var(--space-3);
+    }
+
+    .article-prose h4 {
+      font-size: var(--text-xl);
+      font-weight: var(--weight-medium);
+      margin-top: var(--space-8);
+      margin-bottom: var(--space-2);
+    }
+
+    .article-prose p {
+      font-size: var(--text-base);
+      line-height: var(--leading-relaxed);
+      color: var(--color-text-secondary);
+      margin-bottom: var(--space-5);
+    }
+
+    .article-prose ul,
+    .article-prose ol {
+      list-style: revert;
+      padding-left: var(--space-6);
+      margin-bottom: var(--space-5);
+      color: var(--color-text-secondary);
+      line-height: var(--leading-relaxed);
+    }
+
+    .article-prose li { margin-bottom: var(--space-2); }
+
+    .article-prose img {
+      border-radius: var(--radius-md);
+      border: 1px solid var(--color-border);
+      margin: var(--space-8) 0;
+    }
+
+    .article-header {
+      padding: var(--space-16) 0 var(--space-10);
+      border-bottom: 1px solid var(--color-border);
+      margin-bottom: var(--space-12);
+    }
+
+    .article-header__back {
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--color-text-muted);
+      display: inline-block;
+      margin-bottom: var(--space-6);
+      transition: color var(--transition-fast);
+    }
+    .article-header__back:hover { color: var(--color-accent); }
+
+    .article-header__title {
+      font-size: var(--text-4xl);
+      font-weight: var(--weight-bold);
+      letter-spacing: -0.03em;
+      line-height: var(--leading-tight);
+      margin-bottom: var(--space-4);
+    }
+
+    .article-header__meta {
+      display: flex;
+      align-items: center;
+      gap: var(--space-4);
+      flex-wrap: wrap;
+    }
+
+    .article-header__date {
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      color: var(--color-text-muted);
+      letter-spacing: 0.06em;
+    }
+
+    /* === Orientation block (first blockquote after the title) === */
+    .article-prose > blockquote:first-child {
+      border-left: 3px solid var(--color-accent);
+      background: var(--color-surface);
+      border-radius: var(--radius-md);
+      padding: var(--space-5) var(--space-6);
+      margin: 0 0 var(--space-10);
+    }
+    .article-prose > blockquote:first-child p {
+      margin-bottom: var(--space-3);
+    }
+    .article-prose > blockquote:first-child p:last-child {
+      margin-bottom: 0;
+    }
+
+    /* === Heading anchor links === */
+    .heading-anchor {
+      margin-left: var(--space-2);
+      color: var(--color-text-muted);
+      font-size: 0.7em;
+      opacity: 0;
+      text-decoration: none;
+      transition: opacity var(--transition-fast);
+    }
+    h2:hover .heading-anchor,
+    h3:hover .heading-anchor { opacity: 1; }
+    .heading-anchor:hover { color: var(--color-accent); }
+
+    /* === Two-column layout with "On this page" panel === */
+    .article-layout { display: block; }
+    .article-toc { display: none; }
+
+    @media (min-width: 1200px) {
+      .article-layout {
+        display: grid;
+        grid-template-columns: minmax(0, var(--container-max)) 220px;
+        gap: var(--space-16);
+        justify-content: center;
+        /* grid items stretch by default: the aside spans the full article
+           height, giving the sticky inner panel room to travel */
+      }
+      .article-toc { display: block; }
+    }
+
+    .article-toc__inner {
+      position: sticky;
+      /* clear the fixed site header, plus breathing room */
+      top: calc(var(--header-height) + var(--space-6));
+      max-height: calc(100vh - var(--header-height) - var(--space-12));
+      overflow-y: auto;
+      padding-left: var(--space-4);
+      border-left: 1px solid var(--color-border);
+    }
+
+    .article-toc__title {
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--color-text-muted);
+      margin-bottom: var(--space-4);
+    }
+
+    .article-toc__list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .article-toc__item { margin-bottom: var(--space-2); }
+    .article-toc__item--h3 { padding-left: var(--space-4); }
+
+    .article-toc__list a {
+      display: block;
+      font-size: var(--text-sm);
+      line-height: var(--leading-snug, 1.4);
+      color: var(--color-text-muted);
+      text-decoration: none;
+      transition: color var(--transition-fast);
+    }
+    .article-toc__list a:hover { color: var(--color-text-primary); }
+    .article-toc__list a.active {
+      color: var(--color-accent);
+      font-weight: var(--weight-medium);
+    }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
+  <!-- =========================================================
+       HEADER
+  ========================================================== -->
+  <header class="site-header" role="banner">
+    <div class="container container--wide">
+      <a href="../index.html" class="site-logo">Bruno Ramos Martins</a>
+
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="site-nav">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+
+      <nav id="site-nav" class="site-nav" role="navigation" aria-label="Main navigation">
+        <a href="../index.html">Home</a>
+        <a href="../projects.html">Projects</a>
+        <a href="../articles.html" class="active" aria-current="page">Articles</a>
+        <a href="../til.html">TIL</a>
+        <a href="../resume.html">Resume</a>
+        <a href="../about.html">About</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- =========================================================
+       MAIN CONTENT
+  ========================================================== -->
+  <main class="site-main" id="main-content">
+    <div class="container container--wide">
+
+      <!-- Article Header -->
+      <header class="article-header">
+        <a href="../articles.html" class="article-header__back">← Articles</a>
+        <h1 class="article-header__title">Why Your Budget Never Hits the Exact Number</h1>
+        <div class="article-header__meta">
+          <time class="article-header__date" datetime="2026-07-11">Jul 2026</time>
+          <span class="article-header__date">35 min read</span>
+          <div class="tags">
+            <span class="tag" data-category="statistics">statistics</span><span class="tag">monte-carlo</span><span class="tag">simulation</span><span class="tag">probability</span><span class="tag">budgeting</span>
+          </div>
+        </div>
+      </header>
+
+      <div class="article-layout">
+
+        <!-- Article Body — injected by build_blog.py -->
+        <article class="article-prose" aria-label="Article content">
+          <h1 id="why-your-budget-never-hits-the-exact-number">Why Your Budget Never Hits the Exact Number</h1>
+<blockquote>
+<p><strong>What this is.</strong> The mathematical machinery to replace a single budget number with a probability distribution: "we expect to spend R\$ 11.5M" becomes "we are 90% confident spending will fall between R\$ 10.7M and R\$ 12.4M, with a 3% probability of exceeding the ceiling." The approach applies to any budget that decomposes into stochastic components — headcount, projects, procurement, infrastructure; an IT headcount budget is the running case study.</p>
+<p><strong>What you should know before reading.</strong> <em>Required:</em> basic calculus (derivatives, integrals, a Taylor expansion) and basic probability (random variables, PDF/PMF, CDF, expectation, variance). <em>Helpful but not required:</em> prior exposure to the Law of Large Numbers, the Central Limit Theorem, and confidence intervals — all derived from first principles here — and working knowledge of NumPy. <em>Out of scope:</em> how to choose distributions for heavy-tailed data — that is the companion article <a href="probabilistic-cost-modelling.html">The Shape of What You'll Spend</a> — plus Bayesian inference beyond a conceptual example, real-world data quality issues, and time-series forecasting.</p>
+<p><strong>What you will take away.</strong> A working Monte Carlo budget you can build in a day, the proofs that justify trusting it, and the language to present a distribution to leadership as a reserve policy (P90 / P95 / P99) instead of a target.</p>
+<p><strong>Code.</strong> Every figure and number is reproduced by versioned scripts with fixed seeds in the <a href="https://github.com/brunoramosmartins/monte-carlo-budget-article">companion repository</a>.</p>
+</blockquote>
+<hr />
+<h2 id="notation">Notation</h2>
+<table>
+<thead>
+<tr>
+<th>Symbol</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$X_{\text{total}}$</td>
+<td>Total budget cost (random variable)</td>
+</tr>
+<tr>
+<td>$X_k$</td>
+<td>Cost of component $k$</td>
+</tr>
+<tr>
+<td>$n$</td>
+<td>Number of units (headcount, items, etc.)</td>
+</tr>
+<tr>
+<td>$\bar{X}_N$</td>
+<td>Sample mean of $N$ simulations</td>
+</tr>
+<tr>
+<td>$\hat{\theta}_N$</td>
+<td>Monte Carlo estimator</td>
+</tr>
+<tr>
+<td>$\sigma$</td>
+<td>Standard deviation of the cost distribution</td>
+</tr>
+<tr>
+<td>$z_{\alpha/2}$</td>
+<td>Normal quantile for confidence level $1-\alpha$</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Case study notation</strong> (IT headcount):</p>
+<table>
+<thead>
+<tr>
+<th>Symbol</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$S_i$</td>
+<td>Monthly salary of employee $i$</td>
+</tr>
+<tr>
+<td>$\beta$</td>
+<td>Benefits multiplier</td>
+</tr>
+<tr>
+<td>$H_i$</td>
+<td>Overtime hours per employee per month</td>
+</tr>
+<tr>
+<td>$r_{ot}$</td>
+<td>Overtime hourly rate</td>
+</tr>
+<tr>
+<td>$I$</td>
+<td>Number of severe incidents per year</td>
+</tr>
+<tr>
+<td>$C_j$</td>
+<td>Cost of incident $j$</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="introduction">Introduction</h2>
+<p>Someone asks for next year's budget. You open a spreadsheet, multiply quantities by unit costs, add contingencies, round up a little — and deliver a number. A single number.</p>
+<p>But what if that number is just one sample from a distribution you have never seen?</p>
+<p>Every organisation that manages budgets — headcount costs, project expenses, procurement, marketing spend — faces the same ritual. The team produces a point estimate, leadership approves it, and the year unfolds. Months later, during a periodic forecast review, the actual spending deviates. The team adjusts. Another review. Another adjustment. By year-end, the original number looks like little more than an educated guess.</p>
+<h3 id="the-hidden-cost-of-a-point-estimate">The Hidden Cost of a Point Estimate</h3>
+<p>The problem is not that the estimate was wrong. The problem is that a single number carries no information about its own uncertainty — and that ignorance has a price.</p>
+<ul>
+<li><strong>Capital is locked up as fat.</strong> Without knowing the distribution, the prudent move is to over-reserve. Every extra million held against an imagined worst case is a million that cannot fund hiring, a project, or a customer initiative. This is the <strong>opportunity cost of variance you cannot see</strong>.</li>
+<li><strong>Plans break under shocks you did not budget for.</strong> Under-reserving is the symmetric failure: a project halts mid-year because the contingency was set to "the average outcome plus 10%", and the actual outcome lived in the right tail of a distribution nobody modelled. The point estimate gave no warning because it did not describe a tail.</li>
+<li><strong>Forecast revisions look like mistakes.</strong> Every monthly variance against a deterministic budget is read as "a miss". With a distribution, the same variance is read as "we were inside the 80% interval, no action needed" — or "we crossed the 95% line, escalate." The same data, a different decision.</li>
+</ul>
+<p>A point estimate gives you a number. A distribution gives you the <strong>policy</strong>: how much to reserve, when to escalate, and how confident to be at every step.</p>
+<h3 id="what-changes-with-a-distribution">What Changes With a Distribution</h3>
+<p>This article replaces the single number with a <strong>probability distribution</strong>. Using Monte Carlo simulation grounded in the Law of Large Numbers and the Central Limit Theorem, we transform "we expect to spend R$ 11.5M" into "we are 90% confident spending will fall between R$ 10.7M and R$ 12.4M, with a 3% probability of exceeding the ceiling."</p>
+<blockquote>
+<p><strong>A budget is a distribution, not a number.</strong> This single shift changes how budgets are <em>approved</em>, not just how they are <em>calculated</em>. The output is no longer a target — it is a risk profile that a CFO can underwrite.</p>
+</blockquote>
+<p>The approach is <strong>general</strong>: it applies to any budget that can be decomposed into stochastic components — headcount, projects, procurement, licensing, infrastructure. We illustrate with an IT headcount budget (salaries, benefits, overtime, incidents) as a concrete case study, but the mathematical framework transfers directly to any domain.</p>
+<p>The journey proceeds in stages: we formalise <a href="#budget-components-as-random-variables">budget components as random variables</a>, prove that averaging simulations converges to the true answer with <a href="#the-law-of-large-numbers">the Law of Large Numbers</a>, quantify the simulation error with <a href="#the-central-limit-theorem">the Central Limit Theorem</a>, and make the estimator efficient with <a href="#variance-reduction">variance reduction</a>. The <a href="#experiments-and-results">experiments</a> validate everything; <a href="#a-practical-framework">the practical framework</a> turns the math into a decision workflow you can hand to a budget owner on Monday morning.</p>
+<hr />
+<h2 id="the-point-estimate-problem">The Point Estimate Problem</h2>
+<p>A point estimate is a single value used to approximate an unknown parameter. In budget planning, it takes the form:</p>
+<p>$$
+\hat{X} = \sum_{k} (\text{quantity}_k \times \text{unit cost}_k) + \text{contingency}
+$$</p>
+<p>The result is a number — say, R$ 11.5 million. But this number is $E[X_{\text{total}}]$: the expected value of a random variable. It tells us the centre of the distribution. What it discards is everything else:</p>
+<ul>
+<li><strong>Variance:</strong> How spread out are the possible outcomes?</li>
+<li><strong>Skewness:</strong> Is the distribution symmetric, or could costs be pulled higher by a few extreme events?</li>
+<li><strong>Tail risk:</strong> What is the probability of exceeding the approved ceiling?</li>
+<li><strong>Confidence:</strong> How sure are we that the true cost is within ±5% of our estimate?</li>
+</ul>
+<p>In formal terms, the point estimate gives us $E[X]$ but not the distribution $F_X$. Monte Carlo simulation recovers $F_X$ — the full picture.</p>
+<h3 id="what-the-spreadsheet-is-really-doing">What the Spreadsheet Is Really Doing</h3>
+<p>The point estimate is not a <em>missing</em> model. It is a model with hidden assumptions. To make the critique concrete, here is what a typical FP&amp;A spreadsheet computes:</p>
+<blockquote>
+<p><strong>Box: Typical FP&amp;A model</strong></p>
+<ol>
+<li><strong>Best estimate:</strong> $\hat{X} = \sum_k (\text{quantity}_k \times \text{unit cost}_k)$</li>
+<li><strong>Contingency:</strong> $\hat{X}_{\text{budget}} = \hat{X} \times (1 + c)$ for some chosen $c$ (often 5–15%)</li>
+<li><strong>Optimistic / pessimistic scenarios:</strong> $\hat{X} \times 0.9$ and $\hat{X} \times 1.1$, picked by feel</li>
+</ol>
+<p>What this <em>implicitly</em> assumes:</p>
+<ul>
+<li>The output is a constant (no distribution).</li>
+<li>When pressed, the contingency $c$ is a one-sided "buffer for uncertainty" — but how much risk does it actually cover? The spreadsheet does not say.</li>
+<li>The optimistic/pessimistic scenarios trace out a <strong>range</strong>, but with no probability attached. Are they 5th and 95th percentiles? 1st and 99th? The spreadsheet does not say.</li>
+</ul>
+<p>If you are asked "what is the chance we exceed budget by more than 10%?", a deterministic spreadsheet has no answer — only a guess. Monte Carlo does.</p>
+</blockquote>
+<p>The contingency factor is not the problem. The problem is that the spreadsheet <em>had</em> to make a distributional assumption, did so silently, and then refused to tell you which one. Monte Carlo makes the distribution explicit, calibrated, and falsifiable. Before we can simulate from $F_X$, however, we first have to write it down — declaring which budget components are random and which distributions describe them. That is what the next section does.</p>
+<h3 id="the-general-pattern">The General Pattern</h3>
+<p>Any budget with uncertain components can be written as:</p>
+<p>$$
+X_{\text{total}} = \sum_{k=1}^{K} g_k(\mathbf{Z}_k)
+$$</p>
+<p>where $g_k$ is a cost function for component $k$ and $\mathbf{Z}_k$ is a vector of random inputs. The point estimate collapses each $g_k$ to its expected value; Monte Carlo preserves the full joint distribution.</p>
+<hr />
+<h2 id="budget-components-as-random-variables">Budget Components as Random Variables</h2>
+<p>Every component of a budget is potentially a random variable. Treating them as constants is a modelling choice that discards information. The key insight: <strong>identify which components carry meaningful uncertainty, model them probabilistically, and keep the rest deterministic.</strong></p>
+<blockquote>
+<p><strong>Mental model:</strong> <em>if you cannot point to last year's actual value and say "we hit it exactly", that component is random. Model it.</em></p>
+</blockquote>
+<h3 id="the-general-structure">The General Structure</h3>
+<p>A stochastic budget model has three types of components:</p>
+<ol>
+<li><strong>Proportional costs:</strong> quantity × rate, where either or both may be random</li>
+<li><strong>Fixed costs with uncertainty:</strong> known structure but uncertain magnitude</li>
+<li><strong>Rare events:</strong> random count of occurrences × random cost per event (compound process)</li>
+</ol>
+<p>$$
+X_{\text{total}} = \underbrace{\sum_{i=1}^{n} f(Z_i)}_{\text{proportional}} + \underbrace{\text{fixed components}}_{\text{deterministic or low-variance}} + \underbrace{\sum_{j=1}^{N_{\text{events}}} C_j}_{\text{rare events}}
+$$</p>
+<h3 id="operational-decision-table">Operational Decision Table</h3>
+<p>The hardest practical question is <em>which components to model as random</em>. The table below is the working tool — fill in one row per budget component and apply the rule of thumb.</p>
+<table>
+<thead>
+<tr>
+<th>Component</th>
+<th>Random?</th>
+<th>Distribution</th>
+<th>Why</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Salary per employee</td>
+<td>Yes</td>
+<td>LogNormal</td>
+<td>Strictly positive, right-skewed by seniority</td>
+</tr>
+<tr>
+<td>Headcount</td>
+<td>Sometimes</td>
+<td>Poisson (if hiring/attrition modelled)</td>
+<td>Often deterministic in v1; expand later</td>
+</tr>
+<tr>
+<td>Benefits multiplier</td>
+<td>No</td>
+<td>Constant</td>
+<td>Negotiated annually, low variance</td>
+</tr>
+<tr>
+<td>Overtime hours</td>
+<td>Yes</td>
+<td>Poisson</td>
+<td>Discrete count of independent events</td>
+</tr>
+<tr>
+<td>Incident count</td>
+<td>Yes</td>
+<td>Poisson</td>
+<td>Rare events with constant rate</td>
+</tr>
+<tr>
+<td>Incident cost</td>
+<td>Yes</td>
+<td>LogNormal</td>
+<td>Heavy right tail (a few large incidents)</td>
+</tr>
+<tr>
+<td>FX rate (if applicable)</td>
+<td>Yes</td>
+<td>Normal or empirical</td>
+<td>Symmetric around forward rate</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p><strong>Rule of thumb:</strong> model a component as <strong>random</strong> if it satisfies <em>either</em> of these:</p>
+<ul>
+<li>The <strong>coefficient of variation</strong> $\text{CV} = \sigma / \mu \gt 10\%$ for that component.</li>
+<li>It contributes more than ~5% of the total budget in absolute terms — even at low CV, a large share with even modest noise dominates the tail.</li>
+</ul>
+<p>Components below both thresholds can be left deterministic in v1 with negligible loss.</p>
+</blockquote>
+<p>In our case study, salaries and incident costs clear the bar comfortably; the benefits multiplier does not. Overtime sits in between — Poisson with $\lambda_h = 5$ has $\text{CV} = 1/\sqrt{5} \approx 45\%$, but its share of the budget is small (~2%), so the contribution to the total CV is modest.</p>
+<h3 id="a-note-on-correlation">A Note on Correlation</h3>
+<p>The compact form above assumes the components are mutually independent — and inside each component, the units are i.i.d. That is rarely strictly true, and worth flagging:</p>
+<ul>
+<li><strong>Salaries and overtime may be negatively correlated</strong> — senior employees command higher salary but may log fewer overtime hours.</li>
+<li><strong>Incident frequency and severity may be positively correlated</strong> — a chaotic month with many incidents is also a month where each one is harder to contain.</li>
+<li><strong>Macro factors propagate</strong> — inflation lifts salaries, FX, <em>and</em> contract costs together.</li>
+</ul>
+<p>This article assumes independence to keep the math tractable and the case study clean. The cost is that the simulated CIs may slightly <strong>underestimate</strong> real variance when ignored correlations are positive, and <strong>overestimate</strong> it when they are negative. Two ways to handle this in practice:</p>
+<ol>
+<li><strong>Joint distributions / copulas</strong> — the formal answer; use a Gaussian copula to specify pairwise correlations on top of marginal distributions.</li>
+<li><strong>Sensitivity check</strong> — re-run the simulation with the strongest plausible correlation enforced and observe whether the P95 moves materially. If it does, model the correlation. If not, ignore it.</li>
+</ol>
+<p>For a v1 budget, default to independence and flag correlation as a v2 expansion. For a regulated or mission-critical setting, model correlation from the start.</p>
+<h3 id="case-study-it-headcount-budget">Case Study: IT Headcount Budget</h3>
+<p>We instantiate this structure with a concrete example — a 50-person IT team:</p>
+<p><strong>Salaries (LogNormal).</strong> Salaries are strictly positive and right-skewed (a few senior roles earn significantly more). The LogNormal captures this:</p>
+<p>$$
+S_i \sim \text{LogNormal}(\mu_s, \sigma_s^2), \quad \mu_s = 9.2, \; \sigma_s = 0.3
+$$</p>
+<p>$$
+E[S_i] = e^{\mu_s + \sigma_s^2/2} = e^{9.245} \approx R\$ \, 10{,}362
+$$</p>
+<p><strong>Overtime (Poisson).</strong> Hours are discrete, non-negative, and relatively rare:</p>
+<p>$$
+H_i \sim \text{Poisson}(\lambda_h), \quad \lambda_h = 5
+$$</p>
+<p><strong>Incidents (Compound Poisson).</strong> Severe events occur at a random rate with random severity:</p>
+<p>$$
+I \sim \text{Poisson}(\lambda_I), \quad C_j \sim \text{LogNormal}(\mu_I, \sigma_I^2)
+$$</p>
+<p><strong>Total cost:</strong></p>
+<p>$$
+X_{\text{total}} = \underbrace{\sum_{i=1}^{n} S_i \cdot \beta \cdot 12}_{\text{salaries + benefits}} + \underbrace{\sum_{i=1}^{n} H_i \cdot r_{ot} \cdot 12}_{\text{overtime}} + \underbrace{\sum_{j=1}^{I} C_j}_{\text{incidents}}
+$$</p>
+<p>Using linearity of expectation:</p>
+<p>$$
+E[X_{\text{total}}] \approx 11{,}191{,}000 + 240{,}000 + 123{,}500 \approx R\$ \, 11{,}554{,}500
+$$</p>
+<p>The salary component dominates at ~97%. This pattern — one component driving most of the variance — is common across budget types and will matter for variance reduction.</p>
+<h3 id="other-instantiations">Other Instantiations</h3>
+<p>The same structure applies to:</p>
+<table>
+<thead>
+<tr>
+<th>Budget Type</th>
+<th>Proportional</th>
+<th>Fixed</th>
+<th>Rare Events</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>IT Headcount</strong></td>
+<td>Salaries × headcount</td>
+<td>Benefits rate</td>
+<td>Incidents</td>
+</tr>
+<tr>
+<td><strong>Cloud Infrastructure</strong></td>
+<td>Usage × unit price</td>
+<td>Reserved instances</td>
+<td>Outage remediation</td>
+</tr>
+<tr>
+<td><strong>Marketing</strong></td>
+<td>Impressions × CPC</td>
+<td>Platform fees</td>
+<td>Campaign failures</td>
+</tr>
+<tr>
+<td><strong>Construction</strong></td>
+<td>Materials × quantity</td>
+<td>Permits, insurance</td>
+<td>Weather delays, rework</td>
+</tr>
+<tr>
+<td><strong>R&amp;D Projects</strong></td>
+<td>Hours × rate × team size</td>
+<td>Equipment</td>
+<td>Scope changes</td>
+</tr>
+</tbody>
+</table>
+<p>In each case: identify the random components, choose distributions, and simulate.</p>
+<p>A short caveat before moving on. Everything that follows assumes the distributions chosen for each component are <em>correct</em>. Monte Carlo will faithfully simulate from whatever you feed it — including a bad model. A LogNormal salary fit to data that is actually heavy-tailed will produce a CI that looks tight and is wrong. The companion article <a href="probabilistic-cost-modelling.html">The Shape of What You'll Spend</a> treats this question directly — how to pick a distribution from data, when to suspect a heavier tail than your eye says, and what happens to risk estimates when you get it wrong. If you only have time to read one, read this one first; the companion is what stops you from being precisely wrong.</p>
+<p>With the model defined, the next two sections answer the two questions any practitioner asks before trusting a simulation: <em>will the average converge?</em> (the Law of Large Numbers) and <em>how confident can I be after $N$ runs?</em> (the Central Limit Theorem).</p>
+<hr />
+<h2 id="the-law-of-large-numbers">The Law of Large Numbers</h2>
+<p>If we simulate the budget 10,000 times and average the results, will the average converge to the true $E[X_{\text{total}}]$? The Law of Large Numbers says yes.</p>
+<h3 id="chebyshevs-inequality">Chebyshev's Inequality</h3>
+<p>For any random variable $X$ with mean $\mu$ and variance $\sigma^2$:</p>
+<p>$$
+P(|X - \mu| \geq \epsilon) \leq \frac{\sigma^2}{\epsilon^2}
+$$</p>
+<p>This is derived from Markov's inequality applied to $(X - \mu)^2$.</p>
+<h3 id="the-weak-law-of-large-numbers">The Weak Law of Large Numbers</h3>
+<p>Let $X_1, \ldots, X_N$ be i.i.d. with mean $\mu$ and variance $\sigma^2$. The sample mean $\bar{X}_N = \frac{1}{N}\sum X_i$ satisfies:</p>
+<p>$$
+P(|\bar{X}_N - \mu| \geq \epsilon) \leq \frac{\sigma^2}{N\epsilon^2} \to 0 \quad \text{as } N \to \infty
+$$</p>
+<p><strong>Proof.</strong> Since $E[\bar{X}_N] = \mu$ and $\text{Var}(\bar{X}_N) = \sigma^2/N$, applying Chebyshev to $\bar{X}_N$ gives the result immediately. $\blacksquare$</p>
+<p>The Strong Law provides an even stronger guarantee: $\bar{X}_N \to \mu$ almost surely (probability 1).</p>
+<p><strong>For Monte Carlo:</strong> each simulation $X_i$ is one "possible year." The LLN guarantees that averaging $N$ simulated scenarios converges to the true expected cost.</p>
+<figure><img src="../figures/lln_convergence.png" alt="Ten independent runs of the sample mean converging to E[X], with the Chebyshev 95% confidence band." loading="lazy"><figcaption>Ten independent runs of the sample mean converging to E[X], with the Chebyshev 95% confidence band.</figcaption></figure>
+<p>The LLN guarantees we get the right answer eventually. It does not tell us how close we are after, say, $N = 1{,}000$ runs — Chebyshev's bound is a worst case across all distributions, not a sharp estimate. To answer "how confident can I be?" we need the <em>shape</em> of the error, not just its decay. That is what the Central Limit Theorem provides.</p>
+<hr />
+<h2 id="the-central-limit-theorem">The Central Limit Theorem</h2>
+<p>The LLN tells us the estimate converges. The CLT tells us <strong>how fast</strong> — and gives us confidence intervals.</p>
+<blockquote>
+<h3 id="tldr-skip-the-proof-if-you-are-not-auditing-the-math">TL;DR (skip the proof if you are not auditing the math)</h3>
+<ol>
+<li><strong>What it says:</strong> the average of many independent simulations becomes approximately Normal as $N$ grows, <em>regardless of the underlying distribution</em>. Right-skewed costs in, bell curve out.</li>
+<li><strong>What it gives you:</strong> a confidence interval $\bar{X}_N \pm z_{\alpha/2} \cdot s / \sqrt{N}$. With $z_{0.025} = 1.96$, that is the standard 95% CI.</li>
+<li><strong>What it costs you:</strong> $N$ scales as $1/\epsilon^2$. To halve the CI half-width, run 4× more simulations.</li>
+</ol>
+<p>The proof below shows <em>why</em> this works via moment generating functions. The conclusion stands either way.</p>
+</blockquote>
+<h3 id="statement">Statement</h3>
+<p>For i.i.d. variables with mean $\mu$ and variance $\sigma^2$:</p>
+<p>$$
+\frac{\sqrt{N}(\bar{X}_N - \mu)}{\sigma} \xrightarrow{d} N(0, 1)
+$$</p>
+<h3 id="proof-sketch-mgf-approach">Proof Sketch (MGF Approach)</h3>
+<p>Define $W_i = (X_i - \mu)/\sigma$ so that $E[W_i] = 0$ and $\text{Var}(W_i) = 1$. The standardised sum is $Z_N = \frac{1}{\sqrt{N}}\sum W_i$. Its MGF is:</p>
+<p>$$
+M_{Z_N}(t) = \left[M_W\left(\frac{t}{\sqrt{N}}\right)\right]^N
+$$</p>
+<p>Taylor expanding $\log M_W(s) = s^2/2 + O(s^3)$ and substituting $s = t/\sqrt{N}$:</p>
+<p>$$
+\log M_{Z_N}(t) = \frac{t^2}{2} + O\left(\frac{t^3}{\sqrt{N}}\right) \to \frac{t^2}{2}
+$$</p>
+<p>Since $e^{t^2/2}$ is the MGF of $N(0, 1)$, uniqueness gives $Z_N \xrightarrow{d} N(0, 1)$. $\blacksquare$</p>
+<h3 id="confidence-intervals">Confidence Intervals</h3>
+<p>From the CLT, the $(1-\alpha)$ confidence interval for $\mu$ is:</p>
+<p>$$
+\bar{X}_N \pm z_{\alpha/2} \cdot \frac{s_N}{\sqrt{N}}
+$$</p>
+<h3 id="choosing-n">Choosing N</h3>
+<p>To achieve a CI half-width of $\epsilon$:</p>
+<p>$$
+N \geq \left(\frac{z_{\alpha/2} \cdot \sigma}{\epsilon}\right)^2
+$$</p>
+<p>For our case study ($\sigma \approx 493K$, $\epsilon = 100K$, 95%): $N \geq 94$. Remarkably few simulations are needed.</p>
+<figure><img src="../figures/monte-carlo-budget/clt_normality_emergence.png" alt="As N increases, the standardised sample mean converges to the standard Normal distribution." loading="lazy"><figcaption>As N increases, the standardised sample mean converges to the standard Normal distribution.</figcaption></figure>
+<p>With the LLN giving convergence and the CLT giving the error rate, the Monte Carlo estimator is fully specified. We can now state its formal properties.</p>
+<hr />
+<h2 id="the-monte-carlo-estimator">The Monte Carlo Estimator</h2>
+<h3 id="definition">Definition</h3>
+<p>The Monte Carlo estimator of $\theta = E[g(X)]$ is:</p>
+<p>$$
+\hat{\theta}_N = \frac{1}{N} \sum_{i=1}^N g(X_i)
+$$</p>
+<p>where each $g(X_i)$ is the total cost from one simulated scenario.</p>
+<h3 id="properties">Properties</h3>
+<p><strong>Unbiasedness.</strong> $E[\hat{\theta}_N] = \theta$. No systematic bias.</p>
+<p><strong>Consistency.</strong> $\hat{\theta}_N \xrightarrow{P} \theta$ (WLLN). More simulations → more accuracy.</p>
+<p><strong>Asymptotic normality.</strong> $\sqrt{N}(\hat{\theta}_N - \theta)/\sigma_g \xrightarrow{d} N(0, 1)$ (CLT). We can build CIs.</p>
+<p><strong>Convergence rate.</strong> $\text{SE} = \sigma_g / \sqrt{N}$, decaying as $O(1/\sqrt{N})$. This rate is <strong>independent of the dimension</strong> of $X$ — the key advantage over deterministic methods.</p>
+<h3 id="the-scaling-law">The Scaling Law</h3>
+<p>Halving the CI width requires 4× more simulations. This fundamental trade-off motivates variance reduction.</p>
+<blockquote>
+<p><strong>Mental model:</strong> <em>precision is not free. You buy it with simulations — and the price doubles every time you halve the error bar.</em></p>
+</blockquote>
+<h3 id="mean-squared-error">Mean Squared Error</h3>
+<p>Since the estimator is unbiased: $\text{MSE}(\hat{\theta}_N) = \sigma_g^2 / N$.</p>
+<p>The estimator is unbiased, consistent, and asymptotically Normal — everything the theory can promise. What the theory cannot promise is that the <em>model being simulated</em> is right; <a href="#limitations">Limitations</a> catalogues the ways that assumption fails in practice. Before that, there is a performance ceiling to break: the $O(1/\sqrt{N})$ rate is harsh — every halving of the CI requires quadrupling the simulations, and at the precision needed for serious budget decisions that gets expensive fast. The next section shows how to break that ceiling without changing $N$.</p>
+<hr />
+<h2 id="variance-reduction">Variance Reduction</h2>
+<p>The $O(1/\sqrt{N})$ rate means brute-force precision is expensive. Variance reduction techniques achieve tighter confidence intervals <strong>for the same computational budget</strong>.</p>
+<h3 id="control-variates">Control Variates</h3>
+<p>If we know $E[h(X)]$ analytically for some function $h$ correlated with the cost function $g$:</p>
+<p>$$
+\hat{\theta}_{CV} = \hat{\theta}_N - c^*\left(\bar{h}_N - E[h(X)]\right)
+$$</p>
+<p>The optimal coefficient:</p>
+<p>$$
+c^* = \frac{\text{Cov}(g(X), h(X))}{\text{Var}(h(X))}
+$$</p>
+<p>At optimal $c^*$, variance becomes:</p>
+<p>$$
+\text{Var}(\hat{\theta}_{CV}) = \frac{\text{Var}(g(X))}{N}(1 - \rho_{g,h}^2)
+$$</p>
+<p><strong>In our case study:</strong> using total raw salaries as control ($\rho \approx 0.99$) gives roughly a <strong>30× variance reduction</strong> — equivalently, a 5–6× tightening of the 95% CI half-width at any given $N$. In any budget, the dominant cost component with a known analytical mean is the natural control variate.</p>
+<h3 id="antithetic-variates">Antithetic Variates</h3>
+<p>Generate pairs $(X_i, X_i')$ where $X_i'$ is the "mirror" of $X_i$. If $g$ is monotone, the pair averages have lower variance:</p>
+<p>$$
+\text{Var}(\hat{\theta}_{AV}) = \frac{1}{N}[\text{Var}(g(X)) + \text{Cov}(g(X), g(X'))]
+$$</p>
+<p>When $\text{Cov} < 0$ (monotone $g$), variance is reduced.</p>
+<h3 id="stratified-sampling">Stratified Sampling</h3>
+<p>Partition the input space into $K$ strata and sample within each. By the law of total variance:</p>
+<p>$$
+\text{Var}(\hat{\theta}_{SS}) \leq \text{Var}(\hat{\theta}_{MC})
+$$</p>
+<p>Always. Stratification removes between-strata variance.</p>
+<figure><img src="../figures/monte-carlo-budget/variance_reduction_comparison.png" alt="95% CI width versus N for naive Monte Carlo, antithetic variates, and control variates." loading="lazy"><figcaption>95% CI width versus N for naive Monte Carlo, antithetic variates, and control variates.</figcaption></figure>
+<h3 id="why-this-matters-beyond-the-math-compute-roi">Why This Matters Beyond the Math: Compute ROI</h3>
+<p>A 30× variance reduction sounds like a mathematical curiosity. It is a <strong>compute and response-time</strong> result.</p>
+<p>Suppose the naive simulation needs $N = 30{,}000$ runs to deliver a ±R$ 50K confidence interval. With control variates, the same precision lands at $N = 1{,}000$. Translating into engineering reality:</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Naive MC</th>
+<th>With Control Variates</th>
+<th>Practical Implication</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Runs to ±R$ 50K CI</td>
+<td>30,000</td>
+<td>1,000</td>
+<td>30× fewer scenarios</td>
+</tr>
+<tr>
+<td>Wall-clock on a laptop</td>
+<td>~18 s</td>
+<td>~0.6 s</td>
+<td><strong>Real-time interactive update</strong></td>
+</tr>
+<tr>
+<td>Cloud cost per refresh</td>
+<td>~30 vCPU-seconds</td>
+<td>~1 vCPU-second</td>
+<td>Negligible per query</td>
+</tr>
+<tr>
+<td>Suitable for dashboard</td>
+<td>No (too slow)</td>
+<td>Yes</td>
+<td>A CFO can rerun during a board meeting</td>
+</tr>
+</tbody>
+</table>
+<p>The ROI is not the variance number; it is what the variance number <em>enables</em>:</p>
+<ul>
+<li><strong>Live dashboards.</strong> A CFO sliding a headcount parameter and watching the P95 update in milliseconds is a different product from one that takes a coffee break to recompute.</li>
+<li><strong>Sensitivity at scale.</strong> The <a href="#experiments-and-results">sensitivity analysis in the experiments</a> runs the simulation many times, once per parameter variation. Cutting each run by 50× turns an overnight batch into a few-second screen.</li>
+<li><strong>Cheap A/B of model assumptions.</strong> Want to compare LogNormal vs Gamma for salaries? Naive MC makes that a meeting; control variates make it a parameter toggle.</li>
+</ul>
+<p>The math justifies the technique. The compute economics is what gets it shipped.</p>
+<p>So far, the simulation is built once, before the year starts — a static distribution that anchors a one-shot decision. But budgets are not one-shot artefacts; they are revisited every month as real spending data arrives. The next section reframes the same machinery as the <em>first version</em> of a budget that gets updated continuously — a Bayesian extension that turns the one-shot script into a living forecast.</p>
+<hr />
+<h2 id="continuous-budget-updating">Continuous Budget Updating</h2>
+<p>Everything so far built the <strong>first version</strong> of the budget: a probability distribution computed <em>before</em> the year starts, from a fixed model. The previous sections made that estimate convergent, calibrated, and efficient.</p>
+<p>But a budget is not a one-shot artefact. Each month produces actual spending data. Each quarter brings forecast revisions. The static distribution from January is <em>not</em> the right belief in July — by then we have evidence.</p>
+<p>The natural next step is to <strong>let the data update the distribution</strong>. This is the Bayesian view of the same machinery, and it turns the budget from a one-time calculation into a living model.</p>
+<h3 id="from-frequentist-estimate-to-bayesian-update">From Frequentist Estimate to Bayesian Update</h3>
+<p>Bayes' theorem is the mechanism:</p>
+<p>$$
+P(\theta \mid \text{data}) \propto P(\text{data} \mid \theta) \cdot P(\theta)
+$$</p>
+<p>Read in budget terms:</p>
+<ul>
+<li><strong>Prior $P(\theta)$</strong> — the distribution from January. The output of the full simulation in <a href="#experiments-and-results">Experiments and Results</a>, <em>re-cast as a belief about the world</em>.</li>
+<li><strong>Likelihood $P(\text{data} \mid \theta)$</strong> — how plausible the spending observed so far is, under each candidate value of $\theta$.</li>
+<li><strong>Posterior $P(\theta \mid \text{data})$</strong> — the updated distribution after the data arrives. This becomes the prior for the next month.</li>
+</ul>
+<p>Each forecast review is, in practice, an informal Bayesian update. The maturity gain is making it formal — so the update is auditable, the uncertainty shrinks coherently with evidence, and the policy ("escalate if we cross P95") survives across revisions instead of being re-debated each cycle.</p>
+<h3 id="a-concrete-update-example">A Concrete Update Example</h3>
+<p>Model the team's average monthly salary cost as $\theta$. The January Monte Carlo gives a prior $\theta \sim N(\mu_0, \tau_0^2)$ — say, $\mu_0 = R\$ 11.55M$ with $\tau_0 = R\$ 500K$. After three months of observed monthly costs $x_1, x_2, x_3$ with sample variance $\sigma^2$, the posterior is:</p>
+<p>$$
+\theta \mid x_1, x_2, x_3 \sim N\!\left(\frac{\tau_0^{-2} \mu_0 + 3\sigma^{-2} \bar{x}}{\tau_0^{-2} + 3\sigma^{-2}}, \; \frac{1}{\tau_0^{-2} + 3\sigma^{-2}}\right)
+$$</p>
+<p>The posterior mean is a <strong>precision-weighted average</strong> of the prior mean and the data mean. The posterior variance shrinks — the more months observed, the tighter the belief.</p>
+<p>By month 6, the posterior is much narrower than the original prior. By month 12, the year is over and the posterior collapses around the realised cost. The trajectory of posteriors <em>is</em> the forecast.</p>
+<h3 id="static-simulation-vs-bayesian-updating-when-each-fits">Static Simulation vs Bayesian Updating: When Each Fits</h3>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Static simulation (this article's core)</th>
+<th>Bayesian update layer (this section)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Parameters</td>
+<td>Fixed constants of the model</td>
+<td>Random variables with their own distributions</td>
+</tr>
+<tr>
+<td>Prior information</td>
+<td>Encoded implicitly in distribution choice</td>
+<td>Explicit, auditable, can incorporate history</td>
+</tr>
+<tr>
+<td>Output</td>
+<td>Confidence interval</td>
+<td>Credible interval (direct probability of $\theta$)</td>
+</tr>
+<tr>
+<td>Mid-period updating</td>
+<td>Re-run simulation from scratch</td>
+<td>Natural: posterior of month $m$ becomes prior of $m+1$</td>
+</tr>
+<tr>
+<td>Best when</td>
+<td>Building the <em>first</em> budget; no usable history</td>
+<td>Updating an <em>existing</em> budget with monthly data</td>
+</tr>
+<tr>
+<td>Cost</td>
+<td>A single Monte Carlo run</td>
+<td>A simulation engine <strong>plus</strong> a data pipeline</td>
+</tr>
+</tbody>
+</table>
+<h3 id="why-this-matters">Why This Matters</h3>
+<p>A team that ships only the static simulation has built a script. A team that ships the simulation <em>and</em> the updating layer has built a <strong>data product</strong> — a model that lives across the fiscal year, gets better with data, and produces decisions, not just numbers.</p>
+<p>This article focuses on the static simulation because the updating layer inherits its rigour: a Bayesian update on top of a badly-calibrated prior is just a slow way to be wrong. Get the simulation right first; the lifecycle layer is then a small addition. <a href="#a-practical-framework">A Practical Framework</a> returns to this lifecycle view.</p>
+<p>Theory and reframing aside, the question that decides whether any of this matters is: <em>does the engine actually work?</em> The next section answers it experimentally — five controlled studies covering convergence, normality emergence, full simulation, variance reduction, and sensitivity.</p>
+<hr />
+<h2 id="experiments-and-results">Experiments and Results</h2>
+<p>Each experiment follows the same template — <strong>Claim</strong>, <strong>Setup</strong>, <strong>Result</strong>, <strong>Connection</strong> — so the validation reads as a study, not a demo. All runs use fixed seeds; the corresponding scripts in <code>scripts/</code> reproduce every figure exactly.</p>
+<h3 id="experiment-a-lln-convergence">Experiment A — LLN Convergence</h3>
+<p><strong>Claim.</strong> The sample mean converges to the analytical $E[X]$ as $N$ grows, with variance shrinking at rate $O(1/\sqrt{N})$.</p>
+<p><strong>Setup.</strong> 10 independent runs of LogNormal salary draws, $N$ from 1 to 10,000 each; absolute deviation $|\bar{X}_n - E[X]|$ tracked across runs, with the Chebyshev 95% band overlaid.</p>
+<p><strong>Result.</strong> At small $N$, runs spread widely; by $N = 5{,}000$, all 10 runs cluster within R$ 200 of the analytical mean. The empirical decay matches $\sigma/\sqrt{n}$ on a log-log plot.</p>
+<p><strong>Connection.</strong> The Weak Law proved in <a href="#the-law-of-large-numbers">The Law of Large Numbers</a>, observed at finite $N$ (the figure lives in that section).</p>
+<h3 id="experiment-b-clt-normality">Experiment B — CLT Normality</h3>
+<p><strong>Claim.</strong> The standardised sample mean of LogNormal draws converges in distribution to $N(0, 1)$ — right-skewed costs in, bell curve out.</p>
+<p><strong>Setup.</strong> 10,000 repetitions of "draw $n$ LogNormals, standardise the mean", for $n \in \{1, 5, 10, 30, 100\}$; histogram and QQ-plot per $n$, with QQ linearity ($R^2$) as the fit metric.</p>
+<p><strong>Result.</strong> Visibly non-Normal at $n = 1$; by $n = 30$, the histogram closely tracks $N(0,1)$; at $n = 100$, $R^2 \gt 0.999$.</p>
+<p><strong>Connection.</strong> The MGF proof in <a href="#the-central-limit-theorem">The Central Limit Theorem</a>, watched happening (the figure lives in that section).</p>
+<h3 id="experiment-c-full-budget-simulation">Experiment C — Full Budget Simulation</h3>
+<p><strong>Claim.</strong> Monte Carlo recovers the full distribution of $X_{\text{total}}$ — not just its mean — including the ceiling-breach probability no point estimate can produce.</p>
+<p><strong>Setup.</strong> $N = 50{,}000$ iterations of the IT headcount budget model with default parameters, seed 42; ceiling at R$ 12.5M; metrics: relative error of the MC mean vs analytical $E[X]$, 95% CI half-width, P5–P95 range, $P(X \gt \text{ceiling})$.</p>
+<p><strong>Result.</strong> MC mean within 0.1% of analytical. 95% CI half-width approximately R$ 4K. P5–P95 spans ~R$ 1.6M. The probability of exceeding R$ 12.5M is approximately 3%. The distribution is right-skewed.</p>
+<p><strong>Connection.</strong> Instantiates the full model of <a href="#budget-components-as-random-variables">Budget Components as Random Variables</a> and delivers the risk profile promised in <a href="#the-point-estimate-problem">The Point Estimate Problem</a>.</p>
+<figure><img src="../figures/monte-carlo-budget/budget_simulation.png" alt="Budget cost distribution (histogram and CDF) with mean, P5/P95, and the budget ceiling annotated." loading="lazy"><figcaption>Budget cost distribution (histogram and CDF) with mean, P5/P95, and the budget ceiling annotated.</figcaption></figure>
+<h3 id="experiment-d-variance-reduction">Experiment D — Variance Reduction</h3>
+<p><strong>Claim.</strong> Control variates deliver an order-of-magnitude variance reduction at matched $N$; the $O(1/\sqrt{N})$ rate itself does not change.</p>
+<p><strong>Setup.</strong> Naive MC, antithetic variates, and control variates at $N \in \{500, 1{,}000, 2{,}000, 5{,}000, 10{,}000\}$; control variate: total raw salary sum (analytical mean known); metric: 95% CI half-width per method on log-log axes.</p>
+<p><strong>Result.</strong> Control variates reduce CI width by approximately <strong>5–6×</strong> at every $N$ tested (corresponding to a ~30× variance reduction; effective $\rho \approx 0.99$). The antithetic implementation overlaps closely with naive MC — its modest gain reflects that the budget model's compound Poisson structure is hard to "mirror" cleanly with seed-based pairing. The slope on log-log is $-1/2$ for all methods, confirming the $O(1/\sqrt{N})$ rate — variance reduction shifts the <em>intercept</em>, not the rate.</p>
+<p><strong>Connection.</strong> The control-variate formula of <a href="#variance-reduction">Variance Reduction</a> at work (the figure lives in that section); the dominant-component pattern from the case study is exactly why the salary control works so well.</p>
+<h3 id="experiment-e-sensitivity-analysis">Experiment E — Sensitivity Analysis</h3>
+<p><strong>Claim.</strong> A small number of parameters dominates the total budget; sensitivity analysis tells the analyst where modelling effort pays.</p>
+<p><strong>Setup.</strong> The <strong>effective contribution</strong> of each of 8 parameters varied by ±20% (for log-mean parameters, an additive shift of $\ln(1.2)$; for linear parameters, a multiplicative scale), all others held fixed; $N = 10{,}000$ per variation; metric: percentage change in $E[X_{\text{total}}]$ vs the base case.</p>
+<p><strong>Result.</strong> Three parameters dominate, each producing roughly the same ±19–20% swing in $E[X_{\text{total}}]$: the salary mean ($\mu_s$ via $E[S]$), the benefits multiplier ($\beta$), and the headcount ($n$). All three act linearly on the salary component, which is ~97% of the budget. Overtime and incident parameters change the total by less than 1%. <strong>Practical implication:</strong> invest modelling effort in the three salary-cost levers; refining the overtime or incident model is rounding error.</p>
+<p><strong>Connection.</strong> Feeds directly into step 1 of <a href="#a-practical-framework">A Practical Framework</a> — decompose and find what matters — and is only computationally feasible because of <a href="#variance-reduction">Variance Reduction</a>.</p>
+<blockquote>
+<p><strong>Why "effective ±20%" and not raw ±20%?</strong> The salary log-mean $\mu_s$ enters $E[S] = e^{\mu_s + \sigma_s^2/2}$ exponentially. Varying $\mu_s$ by ±20% additively would multiply $E[S]$ by $\approx 6.3\times$ — making the chart visually dominated by $\mu_s$ for a non-business reason. The corrected setup varies the <em>effective expected value</em> of each component, so the ranking reflects business sensitivity, not parameter scale.</p>
+</blockquote>
+<figure><img src="../figures/monte-carlo-budget/sensitivity_tornado.png" alt="Tornado chart ranking each parameter's impact on the expected total budget." loading="lazy"><figcaption>Tornado chart ranking each parameter's impact on the expected total budget.</figcaption></figure>
+<h3 id="key-findings">Key Findings</h3>
+<table>
+<thead>
+<tr>
+<th>Metric</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Analytical $E[X]$</td>
+<td>R$ 11.55M</td>
+</tr>
+<tr>
+<td>MC mean (N=50K)</td>
+<td>Within 0.1% of analytical</td>
+</tr>
+<tr>
+<td>95% CI half-width (N=50K)</td>
+<td>~R$ 4K</td>
+</tr>
+<tr>
+<td>P5–P95 range</td>
+<td>~R$ 1.6M</td>
+</tr>
+<tr>
+<td>P(X exceeds R$ 12.5M)</td>
+<td>~3%</td>
+</tr>
+<tr>
+<td>Most sensitive parameter</td>
+<td>Dominant component's mean</td>
+</tr>
+<tr>
+<td>Best variance reduction</td>
+<td>Control variates (~30× variance, ~5–6× CI width)</td>
+</tr>
+</tbody>
+</table>
+<p>The experiments confirm the engine works. The remaining gap is operational: turning a validated simulation into a workflow that a budget owner can run on Monday morning, present to leadership without losing the audience, and apply across budget types beyond the case study. That is what the practical framework provides.</p>
+<hr />
+<h2 id="a-practical-framework">A Practical Framework</h2>
+<h3 id="when-to-use-monte-carlo">When to Use Monte Carlo</h3>
+<ul>
+<li><strong>Use MC</strong> when the budget has stochastic components and you need to quantify risk — answer "what is the probability of exceeding the ceiling?"</li>
+<li><strong>A spreadsheet suffices</strong> when all components are truly deterministic or when uncertainty is irrelevant to the decision.</li>
+</ul>
+<h3 id="recommended-workflow">Recommended Workflow</h3>
+<ol>
+<li><strong>Decompose the budget</strong> into components. Identify which carry meaningful uncertainty.</li>
+<li><strong>Choose distributions</strong> based on historical data, expert judgement, or analogies (LogNormal for costs, Poisson for counts, Normal for symmetric quantities).</li>
+<li><strong>Compute analytical moments</strong> ($E[X]$, $\text{Var}(X)$) for validation.</li>
+<li><strong>Run a pilot simulation</strong> ($N = 100$–$500$) to estimate $\sigma$ and compute the required $N$.</li>
+<li><strong>Run the full simulation</strong> with the computed $N$. Use control variates if a good control variable exists.</li>
+<li><strong>Report as a distribution:</strong> mean, CI, P(over ceiling), key percentiles.</li>
+</ol>
+<h3 id="the-decision-layer-from-distribution-to-policy">The Decision Layer: From Distribution to Policy</h3>
+<p>A distribution is data. A <em>policy</em> is what makes that data actionable. The shift from "we have a distribution" to "we have a decision rule" is what turns Monte Carlo into a budget tool that runs the year, not a slide that ends a meeting.</p>
+<p><strong>Three policy questions, three percentiles:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Decision</th>
+<th>Question</th>
+<th>Where to look</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>How much to reserve?</strong></td>
+<td>"What budget covers us in 90% of scenarios?"</td>
+<td>$P_{90}$ of the cost distribution</td>
+</tr>
+<tr>
+<td><strong>When to escalate?</strong></td>
+<td>"What spending level signals serious tail risk?"</td>
+<td>$P_{95}$ — crossing it triggers a review</td>
+</tr>
+<tr>
+<td><strong>What is the worst plausible case?</strong></td>
+<td>"What does a 5%-probability bad year look like?"</td>
+<td>$P_{99}$ — capital cushion bound</td>
+</tr>
+</tbody>
+</table>
+<p><strong>A concrete decision rule</strong> (replace the values with what your organisation accepts):</p>
+<blockquote>
+<p><strong>Capital allocation policy.</strong> Reserve $P_{90}$ as the planned budget. Hold an additional cushion equal to $P_{99} - P_{90}$ as risk capital, available but not committed. If realised year-to-date spending crosses the trajectory's $P_{95}$, escalate to leadership for active review.</p>
+</blockquote>
+<p>This converts the distribution into three numbers any budget owner can act on — and it makes the implicit "how much risk do we accept?" debate explicit.</p>
+<p><strong>The risk vs capital trade-off.</strong> Higher percentiles reserve more capital but lock up cash; lower percentiles free capital but raise the probability of mid-year breach. The right percentile is a <em>business</em> choice, not a statistical one — but Monte Carlo is what lets you choose with numbers attached.</p>
+<table>
+<thead>
+<tr>
+<th>Policy</th>
+<th>Reserved capital</th>
+<th>Probability of breach</th>
+<th>Best for</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$P_{75}$</td>
+<td>Low</td>
+<td>25%</td>
+<td>Highly liquid teams; can re-finance mid-year</td>
+</tr>
+<tr>
+<td>$P_{90}$</td>
+<td>Moderate</td>
+<td>10%</td>
+<td><strong>Default for most teams</strong></td>
+</tr>
+<tr>
+<td>$P_{95}$</td>
+<td>Higher</td>
+<td>5%</td>
+<td>Regulated environments; reputational cost of breach</td>
+</tr>
+<tr>
+<td>$P_{99}$</td>
+<td>High</td>
+<td>1%</td>
+<td>Mission-critical; breach = project death</td>
+</tr>
+</tbody>
+</table>
+<h3 id="how-to-present-results">How to Present Results</h3>
+<p>The single highest-leverage moment in this whole article is the language a budget owner uses in front of leadership. Print this side-by-side comparison and stick it on the wall.</p>
+<blockquote>
+<p><strong>Before — point estimate:</strong></p>
+<p><em>"The budget for next year is R$ 11.55M."</em></p>
+<p>A target. No risk attached. Every variance reads as a miss.</p>
+<p><strong>After — distribution + policy:</strong></p>
+<p><em>"We are 95% confident the cost will fall between R$ 10.7M and R$ 12.4M, with a mean of R$ 11.55M.</em></p>
+<p><em>We propose to reserve R$ 12.0M as the planned budget (P90), with an additional R$ 500K of risk capital available if needed (P99). The probability of exceeding R$ 12.5M is approximately 3%. The primary driver of uncertainty is [dominant component] — investing in better salary forecasts will tighten the range more than any other action."</em></p>
+<p>A risk profile leadership can underwrite. Variances read against the <em>interval</em>, not the mean.</p>
+</blockquote>
+<p>The "After" script is not longer because it is more verbose — it is longer because it carries the <strong>information the spreadsheet had to throw away</strong>. Practise saying it out loud.</p>
+<h3 id="minimum-viable-implementation-1-day">Minimum Viable Implementation (1 Day)</h3>
+<p>You do not need a finished pipeline to start. The minimum useful version of this method takes a single working day. Use this checklist:</p>
+<ol>
+<li><strong>Pick the 2–3 components that drive most of the budget.</strong> For headcount: salaries + overtime + incidents. Ignore the rest for v1.</li>
+<li><strong>Choose default distributions:</strong></li>
+<li>Costs that are strictly positive and right-skewed → <strong>LogNormal</strong></li>
+<li>Counts of rare events (incidents, hires) → <strong>Poisson</strong></li>
+<li>Symmetric, well-known quantities → <strong>Normal</strong></li>
+<li><strong>Estimate parameters from last year's data</strong> or expert judgement. For LogNormal: $\mu = \ln(\text{median})$, $\sigma = $ rough log-scale spread (start with 0.3).</li>
+<li><strong>Run $N = 1{,}000$</strong> simulations in Python with <code>numpy.random.default_rng(42)</code>. About fifty lines of code.</li>
+<li><strong>Report three numbers:</strong> mean, $P_{95}$, $P(X \gt \text{ceiling})$. That is the budget summary.</li>
+</ol>
+<p>If those numbers are useful, you have just earned the right to invest in v2 — adding more components, control variates, monthly Bayesian updates. If they are not useful, you spent one day and learned which components needed more care. Either way, you are ahead of the spreadsheet.</p>
+<h3 id="adapting-to-your-context">Adapting to Your Context</h3>
+<table>
+<thead>
+<tr>
+<th>Your Budget</th>
+<th>Dominant Component</th>
+<th>Natural Control Variate</th>
+<th>Likely Distribution</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Headcount</td>
+<td>Salaries</td>
+<td>Total raw salary sum</td>
+<td>LogNormal</td>
+</tr>
+<tr>
+<td>Cloud/Infra</td>
+<td>Compute usage</td>
+<td>Reserved capacity cost</td>
+<td>LogNormal or Gamma</td>
+</tr>
+<tr>
+<td>Projects</td>
+<td>Labour hours</td>
+<td>Planned hours × rate</td>
+<td>LogNormal</td>
+</tr>
+<tr>
+<td>Procurement</td>
+<td>Unit prices</td>
+<td>Contract baseline</td>
+<td>Normal or Uniform</td>
+</tr>
+<tr>
+<td>Marketing</td>
+<td>Conversion volume</td>
+<td>Historical CPA</td>
+<td>Poisson × LogNormal</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="limitations">Limitations</h2>
+<p>Monte Carlo is a faithful estimator of $E[g(X)]$ <em>given a model</em>. It is <strong>not</strong> a check that the model is right. The estimator can be unbiased, consistent, and asymptotically normal — and still produce conclusions that are confidently wrong. The most common failure modes:</p>
+<ol>
+<li>
+<p><strong>Misspecified distribution.</strong> You picked Normal where the truth is heavy-tailed, or used a Poisson rate calibrated on a quiet year. The simulated CI shrinks around a centre that is wrong; everything downstream inherits the bias. <em>Mitigation:</em> fit distributions on multi-year data when possible, plot Q-Q against the proposed distribution, and run a sensitivity to alternative families (LogNormal vs Gamma vs heavy-tailed Pareto).</p>
+</li>
+<li>
+<p><strong>Ignored correlation.</strong> Treating components as independent when they covary positively under-estimates variance. The CI looks tight — and breaks at the first joint shock. <em>Mitigation:</em> when in doubt, re-run with a Gaussian copula at the maximum plausible correlation. If the P95 moves materially, model it; if not, document the assumption.</p>
+</li>
+<li>
+<p><strong>Heavy tails the model does not capture.</strong> Heavy-tailed phenomena (incident severities, FX shocks, project overruns) can violate the variance-finite assumption that underpins the CLT. The sample mean still converges, but the CI based on $z_{\alpha/2} \sigma / \sqrt{N}$ is over-confident. <em>Mitigation:</em> check the empirical tail decay; if it looks polynomial rather than exponential, switch to a heavy-tailed family (Pareto, Student-$t$). The companion article <a href="probabilistic-cost-modelling.html">The Shape of What You'll Spend</a> covers this directly.</p>
+</li>
+<li>
+<p><strong>Pilot variance under-estimates true variance.</strong> The minimum-$N$ formula $N \geq (z \sigma / \epsilon)^2$ uses a sample $\sigma$ from the pilot run. If the pilot was small or unlucky, $\sigma$ is low-biased — and the actual CI is wider than promised. <em>Mitigation:</em> always re-check the CI half-width <em>after</em> the full run. If it overshoots the target, run more.</p>
+</li>
+<li>
+<p><strong>The decision is not in the bulk.</strong> Monte Carlo gives best precision at the centre of the distribution and worst at the tails. Decisions framed around the median or mean (e.g., "expected cost") are reliable; decisions framed around extreme percentiles (e.g., "1-in-1000-year shortfall") need much larger $N$ to estimate the same percentile with the same precision. <em>Mitigation:</em> if you care about extreme tails, switch to importance sampling or extreme-value theory — naive MC is not the right tool.</p>
+</li>
+</ol>
+<p>The honest claim is narrower than "Monte Carlo gives the answer". It is: <em>Monte Carlo gives the answer that the model implies</em>. Failures upstream of the simulation — wrong distribution, wrong dependencies, wrong tail — are not detected by the simulation itself. Validate them separately.</p>
+<hr />
+<h2 id="conclusion">Conclusion</h2>
+<p>A single-number budget is an <strong>incomplete model</strong>. It compresses a distribution into its centre, throws away every tail, and asks the organisation to make capital allocation decisions on what is left.</p>
+<p>That compression has a cost. Capital is over-reserved against fears nobody quantified, or under-reserved against tails nobody saw. Forecast variances are read as errors instead of as draws from a distribution. The CFO is asked to underwrite a target, not a risk.</p>
+<p>This article built the mathematical machinery to replace the single number with a probability distribution. We proved the estimator converges (LLN), quantified its error (CLT), and made the simulation efficient (variance reduction). The experimental validation confirmed it works: Monte Carlo recovers the analytical mean within 0.1%, control variates give roughly a 30× variance reduction (5–6× tighter CI), and the most sensitive parameter is exactly the dominant cost component — telling the analyst where to spend modelling effort.</p>
+<p>But the deeper claim is not technical. It is this:</p>
+<blockquote>
+<p><strong>A budget is a distribution, not a number. Variance is what breaks plans, not the mean. Simulation turns uncertainty into measurable risk.</strong></p>
+</blockquote>
+<p>Three sentences. Print them above the spreadsheet.</p>
+<p>Any serious budget should be expressed as a distribution. Any serious budget review should ask "where in the distribution did we land?", not "by how much did we miss?". And any serious team building a budget today should be running the kind of simulation this article describes — by Monday, on a laptop, in a hundred lines of Python.</p>
+<p>The next time someone asks for a budget number, give them a distribution. And when you are ready to choose <em>which</em> distributions to feed the simulation, the companion article <a href="probabilistic-cost-modelling.html">The Shape of What You'll Spend</a> is the natural next read.</p>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li>Casella, G. &amp; Berger, R. (2002). <em>Statistical Inference</em>. Duxbury.</li>
+<li>Gelman, A. et al. (2013). <em>Bayesian Data Analysis</em>. CRC Press.</li>
+<li>Glasserman, P. (2003). <em>Monte Carlo Methods in Financial Engineering</em>. Springer.</li>
+<li>Robert, C. &amp; Casella, G. (2004). <em>Monte Carlo Statistical Methods</em>. Springer.</li>
+</ul>
+<hr />
+<p><em>All figures and numbers in this article are reproduced by versioned scripts with fixed seeds in the <a href="https://github.com/brunoramosmartins/monte-carlo-budget-article">companion repository</a>. See the repository README for how to run them.</em></p>
+          
+        </article>
+
+        <!-- On This Page — populated by articleToc.js from heading ids -->
+        <aside class="article-toc" aria-label="On this page">
+          <nav class="article-toc__inner">
+            <p class="article-toc__title">On this page</p>
+            <ul class="article-toc__list" id="article-toc-list"></ul>
+          </nav>
+        </aside>
+
+      </div>
+
+    </div>
+  </main>
+
+  <!-- =========================================================
+       FOOTER
+  ========================================================== -->
+  <footer class="site-footer" role="contentinfo">
+    <div class="container container--wide">
+      <span class="footer-copy">© 2026 Bruno Ramos Martins</span>
+      <nav class="footer-links" aria-label="Footer navigation">
+        <a href="https://github.com/brunoramosmartins" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://www.linkedin.com/in/bruno-ramos-martins-22a6a61a0/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+        <a href="../about.html">About</a>
+      </nav>
+    </div>
+  </footer>
+
+  <!-- Nav toggle script -->
+  <script src="../assets/js/navigation.js" defer></script>
+  <!-- On This Page panel + heading anchors + scroll spy -->
+  <script src="../assets/js/articleToc.js" defer></script>
+
+</body>
+</html>

--- a/posts/not-all-errors-cost-the-same.html
+++ b/posts/not-all-errors-cost-the-same.html
@@ -179,8 +179,9 @@
 
     .article-toc__inner {
       position: sticky;
-      top: var(--space-8);
-      max-height: calc(100vh - var(--space-16));
+      /* clear the fixed site header, plus breathing room */
+      top: calc(var(--header-height) + var(--space-6));
+      max-height: calc(100vh - var(--header-height) - var(--space-12));
       overflow-y: auto;
       padding-left: var(--space-4);
       border-left: 1px solid var(--color-border);

--- a/posts/probabilistic-cost-modelling.html
+++ b/posts/probabilistic-cost-modelling.html
@@ -1,0 +1,799 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Probabilistic modelling of people costs — from distribution selection to budget impact." />
+  <title>The Shape of What You'll Spend — Bruno Ramos Martins</title>
+
+  <!-- Favicon -->
+  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg" />
+
+  <!-- Open Graph -->
+  <meta property="og:type"        content="article" />
+  <meta property="og:title"       content="The Shape of What You'll Spend — Bruno Ramos Martins" />
+  <meta property="og:description" content="Probabilistic modelling of people costs — from distribution selection to budget impact." />
+  <meta property="og:url"         content="https://brunoramosmartins.github.io/posts/probabilistic-cost-modelling.html" />
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&family=IBM+Plex+Serif:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&display=swap" rel="stylesheet" />
+
+  <!-- MathJax — renders LaTeX math ($...$, $$...$$) -->
+  <script>
+    MathJax = {
+      tex: {
+        inlineMath:  [['$', '$']],
+        displayMath: [['$$', '$$']],
+      },
+    };
+  </script>
+  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
+
+  <!-- Styles -->
+  <link rel="stylesheet" href="../assets/css/base.css" />
+  <link rel="stylesheet" href="../assets/css/layout.css" />
+  <link rel="stylesheet" href="../assets/css/components.css" />
+  <link rel="stylesheet" href="../assets/css/highlight.css" />
+
+  <style>
+    /* === Article-specific prose styles === */
+    .article-prose {
+      max-width: var(--container-max);
+      margin: 0 auto;
+    }
+
+    .article-prose h2 {
+      font-size: var(--text-3xl);
+      font-weight: var(--weight-bold);
+      letter-spacing: -0.02em;
+      margin-top: var(--space-16);
+      margin-bottom: var(--space-4);
+      padding-bottom: var(--space-3);
+      border-bottom: 1px solid var(--color-border);
+    }
+
+    .article-prose h3 {
+      font-size: var(--text-2xl);
+      font-weight: var(--weight-semibold);
+      letter-spacing: -0.01em;
+      margin-top: var(--space-10);
+      margin-bottom: var(--space-3);
+    }
+
+    .article-prose h4 {
+      font-size: var(--text-xl);
+      font-weight: var(--weight-medium);
+      margin-top: var(--space-8);
+      margin-bottom: var(--space-2);
+    }
+
+    .article-prose p {
+      font-size: var(--text-base);
+      line-height: var(--leading-relaxed);
+      color: var(--color-text-secondary);
+      margin-bottom: var(--space-5);
+    }
+
+    .article-prose ul,
+    .article-prose ol {
+      list-style: revert;
+      padding-left: var(--space-6);
+      margin-bottom: var(--space-5);
+      color: var(--color-text-secondary);
+      line-height: var(--leading-relaxed);
+    }
+
+    .article-prose li { margin-bottom: var(--space-2); }
+
+    .article-prose img {
+      border-radius: var(--radius-md);
+      border: 1px solid var(--color-border);
+      margin: var(--space-8) 0;
+    }
+
+    .article-header {
+      padding: var(--space-16) 0 var(--space-10);
+      border-bottom: 1px solid var(--color-border);
+      margin-bottom: var(--space-12);
+    }
+
+    .article-header__back {
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--color-text-muted);
+      display: inline-block;
+      margin-bottom: var(--space-6);
+      transition: color var(--transition-fast);
+    }
+    .article-header__back:hover { color: var(--color-accent); }
+
+    .article-header__title {
+      font-size: var(--text-4xl);
+      font-weight: var(--weight-bold);
+      letter-spacing: -0.03em;
+      line-height: var(--leading-tight);
+      margin-bottom: var(--space-4);
+    }
+
+    .article-header__meta {
+      display: flex;
+      align-items: center;
+      gap: var(--space-4);
+      flex-wrap: wrap;
+    }
+
+    .article-header__date {
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      color: var(--color-text-muted);
+      letter-spacing: 0.06em;
+    }
+
+    /* === Orientation block (first blockquote after the title) === */
+    .article-prose > blockquote:first-child {
+      border-left: 3px solid var(--color-accent);
+      background: var(--color-surface);
+      border-radius: var(--radius-md);
+      padding: var(--space-5) var(--space-6);
+      margin: 0 0 var(--space-10);
+    }
+    .article-prose > blockquote:first-child p {
+      margin-bottom: var(--space-3);
+    }
+    .article-prose > blockquote:first-child p:last-child {
+      margin-bottom: 0;
+    }
+
+    /* === Heading anchor links === */
+    .heading-anchor {
+      margin-left: var(--space-2);
+      color: var(--color-text-muted);
+      font-size: 0.7em;
+      opacity: 0;
+      text-decoration: none;
+      transition: opacity var(--transition-fast);
+    }
+    h2:hover .heading-anchor,
+    h3:hover .heading-anchor { opacity: 1; }
+    .heading-anchor:hover { color: var(--color-accent); }
+
+    /* === Two-column layout with "On this page" panel === */
+    .article-layout { display: block; }
+    .article-toc { display: none; }
+
+    @media (min-width: 1200px) {
+      .article-layout {
+        display: grid;
+        grid-template-columns: minmax(0, var(--container-max)) 220px;
+        gap: var(--space-16);
+        justify-content: center;
+        /* grid items stretch by default: the aside spans the full article
+           height, giving the sticky inner panel room to travel */
+      }
+      .article-toc { display: block; }
+    }
+
+    .article-toc__inner {
+      position: sticky;
+      /* clear the fixed site header, plus breathing room */
+      top: calc(var(--header-height) + var(--space-6));
+      max-height: calc(100vh - var(--header-height) - var(--space-12));
+      overflow-y: auto;
+      padding-left: var(--space-4);
+      border-left: 1px solid var(--color-border);
+    }
+
+    .article-toc__title {
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--color-text-muted);
+      margin-bottom: var(--space-4);
+    }
+
+    .article-toc__list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .article-toc__item { margin-bottom: var(--space-2); }
+    .article-toc__item--h3 { padding-left: var(--space-4); }
+
+    .article-toc__list a {
+      display: block;
+      font-size: var(--text-sm);
+      line-height: var(--leading-snug, 1.4);
+      color: var(--color-text-muted);
+      text-decoration: none;
+      transition: color var(--transition-fast);
+    }
+    .article-toc__list a:hover { color: var(--color-text-primary); }
+    .article-toc__list a.active {
+      color: var(--color-accent);
+      font-weight: var(--weight-medium);
+    }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
+  <!-- =========================================================
+       HEADER
+  ========================================================== -->
+  <header class="site-header" role="banner">
+    <div class="container container--wide">
+      <a href="../index.html" class="site-logo">Bruno Ramos Martins</a>
+
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="site-nav">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+
+      <nav id="site-nav" class="site-nav" role="navigation" aria-label="Main navigation">
+        <a href="../index.html">Home</a>
+        <a href="../projects.html">Projects</a>
+        <a href="../articles.html" class="active" aria-current="page">Articles</a>
+        <a href="../til.html">TIL</a>
+        <a href="../resume.html">Resume</a>
+        <a href="../about.html">About</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- =========================================================
+       MAIN CONTENT
+  ========================================================== -->
+  <main class="site-main" id="main-content">
+    <div class="container container--wide">
+
+      <!-- Article Header -->
+      <header class="article-header">
+        <a href="../articles.html" class="article-header__back">← Articles</a>
+        <h1 class="article-header__title">The Shape of What You'll Spend</h1>
+        <div class="article-header__meta">
+          <time class="article-header__date" datetime="2026-07-11">Jul 2026</time>
+          <span class="article-header__date">23 min read</span>
+          <div class="tags">
+            <span class="tag" data-category="statistics">statistics</span><span class="tag">probability</span><span class="tag">distributions</span><span class="tag">heavy-tails</span><span class="tag">budgeting</span>
+          </div>
+        </div>
+      </header>
+
+      <div class="article-layout">
+
+        <!-- Article Body — injected by build_blog.py -->
+        <article class="article-prose" aria-label="Article content">
+          <h1 id="the-shape-of-what-youll-spend">The Shape of What You'll Spend</h1>
+<blockquote>
+<p><strong>What this is.</strong> A practical framework for choosing probability distributions in people-cost modelling — and for pricing the cost of choosing wrong. The headline result: assuming a Normal instead of the Pareto that actually fits severance data underestimates the probability of extreme expenses by a factor of <strong>138x</strong>, with direct consequences for budget reserves. This is not a probability textbook or a Python tutorial: it assumes you accept that <em>the wrong distribution = the wrong budget</em> and want a rigorous, reproducible way to choose the right one.</p>
+<p><strong>What you should know before reading.</strong> <em>Required:</em> calculus (derivatives, integrals, a basic Taylor expansion), basic probability (PDF, CDF, expectation, variance), and a little linear algebra (matrix inversion appears briefly for Fisher information). <em>Helpful but not required:</em> prior exposure to Maximum Likelihood Estimation and to information criteria — both are derived from first principles here. <em>Out of scope:</em> Bayesian inference and MCMC, time-series and dependence modelling, and real-world data collection concerns (NDA, privacy).</p>
+<p><strong>What you will take away.</strong> A five-step decision procedure — visualise, fit, compare, validate, quantify — that you can apply to your own cost data, plus the vocabulary to defend the choice in front of a finance audience.</p>
+<p><strong>Code.</strong> Every figure and number is reproduced by versioned scripts with fixed seeds in the <a href="https://github.com/brunoramosmartins/probabilistic-cost-modelling-article">companion repository</a>.</p>
+</blockquote>
+<hr />
+<h2 id="notation">Notation</h2>
+<table>
+<thead>
+<tr>
+<th>Symbol</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$X$</td>
+<td>Random variable (a cost component)</td>
+</tr>
+<tr>
+<td>$f(x \mid \theta)$</td>
+<td>Probability density function with parameter $\theta$</td>
+</tr>
+<tr>
+<td>$F(x)$</td>
+<td>Cumulative distribution function</td>
+</tr>
+<tr>
+<td>$\hat{\theta}$</td>
+<td>Maximum Likelihood Estimate of $\theta$</td>
+</tr>
+<tr>
+<td>$\ell(\theta)$</td>
+<td>Log-likelihood function</td>
+</tr>
+<tr>
+<td>$S(\theta)$</td>
+<td>Score function (gradient of $\ell$)</td>
+</tr>
+<tr>
+<td>$I(\theta)$</td>
+<td>Fisher information</td>
+</tr>
+<tr>
+<td>$n$</td>
+<td>Sample size</td>
+</tr>
+<tr>
+<td>$k$</td>
+<td>Number of estimated parameters</td>
+</tr>
+<tr>
+<td>$D_{KL}(p \| q)$</td>
+<td>Kullback-Leibler divergence from $p$ to $q$</td>
+</tr>
+<tr>
+<td>$\text{VaR}_p$</td>
+<td>Value at Risk at confidence level $p$</td>
+</tr>
+<tr>
+<td>$\text{ES}_p$</td>
+<td>Expected Shortfall at level $p$</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="why-distributions-matter">Why Distributions Matter</h2>
+<p>A budget is a probability statement disguised as a spreadsheet. When an analyst projects people costs, they are implicitly assuming a probability distribution for each component — salaries, overtime, severance, hiring. In most organizations, that assumption is the Normal distribution: symmetric, light-tailed, well-behaved.</p>
+<p><strong>That assumption can break a quarter's budget.</strong> Under a Normal distribution, the probability of a severance event exceeding R\$ 50,000 is about 0.013% — once in 77,000 cases. Under the Pareto distribution that actually fits this kind of data, the same probability is 1.79% — once in 56 cases. <strong>A 138x gap.</strong> When that gap shows up in real layoffs, the cash reserve calibrated to the Normal assumption is no longer a safety margin; it is a fiction.</p>
+<p>The problem is that people costs are not Normal. Salaries are right-skewed: most employees earn moderate wages while a few executives pull the mean upward. Severance costs are heavy-tailed: most are moderate, but a few extreme cases dominate the total. Salary data is often multimodal: clusters of juniors, mid-levels, and seniors form distinct peaks that no unimodal distribution can capture.</p>
+<p><strong>The distribution you assume is your model.</strong> Everything else — mean, variance, confidence intervals, risk estimates — flows from that choice. A wrong distribution is not a modelling nuance; it is a systematic bias that propagates through every downstream calculation.</p>
+<p>$$\text{Wrong distribution} \rightarrow \text{wrong parameters} \rightarrow \text{wrong budget} \rightarrow \text{wrong decisions}$$</p>
+<p>This article presents a rigorous framework for distribution selection in cost modelling. We derive Maximum Likelihood Estimation (MLE) from first principles, fit five candidate distribution families to synthetic cost data, and use information-theoretic criteria (AIC, BIC) and goodness-of-fit tests to select the best model. The companion article <a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a> shows how to use these distributions to simulate total team cost.</p>
+<hr />
+<h2 id="whats-at-stake">What's at Stake</h2>
+<p>Before diving into the formalism, three numbers frame why the choice matters. The figure below previews the central comparison: under a Normal model, the budget reserve looks comfortable — until reality follows a Pareto.</p>
+<figure><img src="../figures/probabilistic-cost-modelling/wrong_distribution_impact.png" alt="What's at stake: budget reserve under correct vs wrong distributional assumption" loading="lazy"><figcaption>What's at stake: budget reserve under correct vs wrong distributional assumption</figcaption></figure>
+<p><strong>Three concrete impacts on a 50-person team:</strong></p>
+<ol>
+<li>
+<p><strong>Tail probability gap (severance):</strong> $P(X > 50{,}000)$ — i.e., the probability of a severance event exceeding R\$ 50,000 — is <strong>138x higher</strong> under Pareto than under Normal. The "rare event" that the Normal predicts becomes a routine occurrence under the correct model.</p>
+</li>
+<li>
+<p><strong>Hidden bimodality (salary):</strong> A single Normal fit to a juniors/seniors mixture inflates the variance estimate by ~40% while the mean represents no actual employee. The 95% VaR ends up wrong in both directions.</p>
+</li>
+<li>
+<p><strong>Reserve underfunding (annual budget):</strong> For a 50-person team where salaries are LogNormal and severance is Pareto, defaulting to Normal underestimates the 99% VaR reserve by <strong>R\$ 100,000–R\$ 150,000 per year</strong>. That is the gap between "we have a buffer" and "we are exposed."</p>
+</li>
+</ol>
+<p>The rest of the article shows how to detect, quantify, and correct each of these gaps.</p>
+<hr />
+<h2 id="the-cost-components">The Cost Components</h2>
+<p>To make the framework concrete, we need a model of what we're estimating. We represent each cost component as a random variable with distinct distributional properties. The model is generic, minimal, and expandable.</p>
+<table>
+<thead>
+<tr>
+<th>Component</th>
+<th>Symbol</th>
+<th>Candidates</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Base salary</td>
+<td>$S_i$</td>
+<td>LogNormal, Gamma, Mixture(Normal)</td>
+<td>Right-skewed; multimodal if clusters exist</td>
+</tr>
+<tr>
+<td>Overtime cost</td>
+<td>$C_{ot}$</td>
+<td>LogNormal, Gamma</td>
+<td>Right-skewed, always positive</td>
+</tr>
+<tr>
+<td>Severance cost</td>
+<td>$C_{sev}$</td>
+<td><strong>Pareto</strong>, LogNormal</td>
+<td>Heavy-tailed: a few extremely expensive cases</td>
+</tr>
+<tr>
+<td>Hiring cost</td>
+<td>$C_h$</td>
+<td>LogNormal, Gamma</td>
+<td>Variable (recruiter fees, relocation)</td>
+</tr>
+<tr>
+<td>Benefits multiplier</td>
+<td>$\beta_i$</td>
+<td>Uniform, Beta</td>
+<td>Bounded: typically 1.3x–2.2x of salary</td>
+</tr>
+</tbody>
+</table>
+<h3 id="the-spreadsheet-baseline">The Spreadsheet Baseline</h3>
+<p>Before introducing better models, it helps to name the one being replaced. The typical FP&amp;A spreadsheet treats each cost component as $\bar{x} \pm k \cdot s$ — a mean and a standard deviation, often with $k = 2$ or $k = 3$. This is implicitly a Normal model: it assumes symmetric, light-tailed behaviour around the mean. For salaries it underestimates the right tail; for severance it underestimates catastrophically. The framework below is a structured replacement for this implicit baseline.</p>
+<h3 id="concrete-example-50-person-team">Concrete Example: 50-Person Team</h3>
+<p>Consider an IT team with 50 employees. Using parameters calibrated to the Brazilian market:</p>
+<ul>
+<li><strong>Salaries</strong>: LogNormal($\mu = 9.1$, $\sigma = 0.4$), median ~ R\$ 9,000/month</li>
+<li><strong>Overtime</strong>: Gamma($\alpha = 4$, $\beta = 1/30$), mean ~ R\$ 120/hour</li>
+<li><strong>Severance</strong>: Pareto($\alpha = 2.5$, $x_m = 10,000$), ~3 events/year</li>
+<li><strong>Hiring</strong>: LogNormal($\mu = 9.5$, $\sigma = 0.7$), ~5 hires/year</li>
+</ul>
+<p>The expected total annual cost is approximately R\$ 6.0–6.5 million. The crucial question: the <em>variance</em> of this total depends critically on which distributions you assume. Normal assumptions produce a narrow confidence interval; correct heavy-tailed assumptions produce a much wider one.</p>
+<hr />
+<h2 id="distribution-families">Distribution Families</h2>
+<p>Now that we know which components we need to model, we need a vocabulary of candidate distributions that can capture their distinct shapes. For each component, we consider five distribution families. The Normal is included as the baseline to beat — not as a serious candidate.</p>
+<h3 id="the-five-candidates">The Five Candidates</h3>
+<p><strong>Normal</strong> $N(\mu, \sigma^2)$: The default assumption — and frequently wrong. Symmetric, light-tailed, support on $(-\infty, \infty)$. Assigns positive probability to negative costs, which is physically impossible for salaries.</p>
+<p><strong>LogNormal</strong> $\text{LogNormal}(\mu, \sigma^2)$: If $Y \sim N(\mu, \sigma^2)$, then $X = e^Y$ is LogNormal. Always positive, right-skewed, arises naturally from multiplicative processes (salary = base $\times$ promotions $\times$ adjustments). Median $= e^\mu$.</p>
+<p><strong>Gamma</strong> $\text{Gamma}(\alpha, \beta)$: Always positive, flexible shape controlled by $\alpha$. For $\alpha < 1$, highly skewed; for $\alpha \gg 1$, nearly symmetric. Natural for "accumulation" costs (overtime across a month).</p>
+<p><strong>Pareto</strong> $\text{Pareto}(\alpha, x_m)$: The power-law distribution. Heavy-tailed: $P(X > x) = (x_m/x)^\alpha$ decays polynomially, not exponentially. Models extreme costs (million-dollar severance packages). For $\alpha \leq 2$, infinite variance.</p>
+<p><strong>Weibull</strong> $\text{Weibull}(k, \lambda)$: Flexible shape, closed-form CDF. The hazard function can be increasing ($k > 1$), constant ($k = 1$, = Exponential), or decreasing ($k < 1$). Useful for "time to event" costs.</p>
+<h3 id="comparison-table">Comparison Table</h3>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Normal</th>
+<th>LogNormal</th>
+<th>Gamma</th>
+<th>Pareto</th>
+<th>Weibull</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Support</td>
+<td>$(-\infty, \infty)$</td>
+<td>$(0, \infty)$</td>
+<td>$(0, \infty)$</td>
+<td>$[x_m, \infty)$</td>
+<td>$[0, \infty)$</td>
+</tr>
+<tr>
+<td>Skewness</td>
+<td>0</td>
+<td>$> 0$ always</td>
+<td>$2/\sqrt{\alpha}$</td>
+<td>heavy</td>
+<td>depends on $k$</td>
+</tr>
+<tr>
+<td>Tail</td>
+<td>Light</td>
+<td>Sub-exponential</td>
+<td>Light</td>
+<td><strong>Heavy</strong></td>
+<td>Light</td>
+</tr>
+<tr>
+<td>MGF exists?</td>
+<td>Yes</td>
+<td>No</td>
+<td>Yes</td>
+<td>No</td>
+<td>Series only</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Mental hook:</strong> <em>Normal assumes symmetry; cost reality is asymmetric.</em> The Normal distribution is <strong>not</strong> a primary candidate for any individual cost component. It may be appropriate for the <em>total</em> budget (by CLT), but not for individual cost shapes.</p>
+<figure><img src="../figures/probabilistic-cost-modelling/distribution_zoo.png" alt="Candidate distributions fitted to the same salary data" loading="lazy"><figcaption>Candidate distributions fitted to the same salary data</figcaption></figure>
+<hr />
+<h2 id="maximum-likelihood-estimation">Maximum Likelihood Estimation</h2>
+<p>We have candidate families. We now need a principled way to choose the <em>parameters</em> of each family from observed data. Maximum Likelihood Estimation (MLE) is the workhorse: it gives us optimal point estimates, automatic standard errors via Fisher information, and a foundation for the <a href="#model-comparison">model comparison framework</a> that comes next.</p>
+<h3 id="the-estimation-problem">The Estimation Problem</h3>
+<p>Given a dataset $x_1, \ldots, x_n$ and a distribution family $f(x \mid \theta)$, we want to find the parameter $\theta$ that best explains the observed data.</p>
+<h3 id="the-likelihood-function">The Likelihood Function</h3>
+<p>$$L(\theta \mid \mathbf{x}) = \prod_{i=1}^n f(x_i \mid \theta)$$</p>
+<p>The log-likelihood (numerically stable):</p>
+<p>$$\ell(\theta) = \sum_{i=1}^n \log f(x_i \mid \theta)$$</p>
+<p>The <strong>maximum likelihood estimator</strong> (MLE) maximizes $\ell(\theta)$:</p>
+<p>$$\hat{\theta}_{MLE} = \arg\max_\theta \ell(\theta)$$</p>
+<blockquote>
+<p><strong>Intuition.</strong> The likelihood asks: <em>"how plausible is this parameter, given the data I observed?"</em> The MLE picks the parameter that makes the observed data most plausible. For a Normal, this turns out to be the sample mean and variance — confirming that everyday statistics is implicitly MLE under a Normal assumption.</p>
+</blockquote>
+<h3 id="score-function-and-fisher-information">Score Function and Fisher Information</h3>
+<p>The <strong>score function</strong> is the gradient of the log-likelihood:</p>
+<p>$$S(\theta) = \frac{\partial \ell}{\partial \theta}$$</p>
+<p><strong>Fundamental property</strong>: $E[S(\theta_0)] = 0$ at the true parameter. Proof: differentiate $\int f(x|\theta) dx = 1$ under the integral sign.</p>
+<p><strong>Fisher information</strong> measures the curvature of the log-likelihood:</p>
+<p>$$I(\theta) = \text{Var}[S(\theta)] = -E\left[\frac{\partial^2 \ell}{\partial \theta^2}\right]$$</p>
+<blockquote>
+<p><strong>Intuition.</strong> <em>Curvature equals precision.</em> A sharp, narrow log-likelihood peak means the data strongly identifies the parameter; a flat peak means many parameters are roughly equally plausible. Fisher information formalizes this.</p>
+</blockquote>
+<h3 id="asymptotic-normality">Asymptotic Normality</h3>
+<p>For large $n$, the MLE is approximately Normal:</p>
+<p>$$\hat{\theta}_{MLE} \dot{\sim} N\left(\theta_0, \frac{1}{n \cdot I_1(\theta_0)}\right)$$</p>
+<p>This gives us automatic confidence intervals:</p>
+<p>$$\hat{\theta} \pm z_{\alpha/2} \cdot \frac{1}{\sqrt{n \cdot I_1(\hat{\theta})}}$$</p>
+<p>In practice: we report not just the parameter estimate but also its uncertainty — and that uncertainty shrinks as $1/\sqrt{n}$ as more data comes in.</p>
+<h3 id="mle-for-our-distributions">MLE for Our Distributions</h3>
+<ul>
+<li><strong>Normal</strong>: $\hat{\mu} = \bar{x}$, $\hat{\sigma}^2 = \frac{1}{n}\sum(x_i - \bar{x})^2$ (closed form)</li>
+<li><strong>LogNormal</strong>: $\hat{\mu} = \overline{\log x}$, $\hat{\sigma}^2 = \text{Var}(\log x)$ (closed form, via log-transform)</li>
+<li><strong>Gamma</strong>: $\hat{\beta} = \hat{\alpha}/\bar{x}$, $\hat{\alpha}$ via numerical solution (digamma equation)</li>
+<li><strong>Pareto</strong> ($x_m$ known): $\hat{\alpha} = n / \sum \log(x_i/x_m)$ (closed form)</li>
+<li><strong>Weibull</strong>: both parameters via numerical optimization</li>
+</ul>
+<figure><img src="../figures/probabilistic-cost-modelling/mle_convergence.png" alt="MLE Convergence: estimates converge to true parameters as n grows" loading="lazy"><figcaption>MLE Convergence: estimates converge to true parameters as n grows</figcaption></figure>
+<hr />
+<h2 id="model-comparison">Model Comparison</h2>
+<p>We can now fit any candidate to data. But fitting alone doesn't tell us which family is the right one — and a model with more parameters will always fit training data better. The question becomes: how do we select between fitted models without rewarding complexity for its own sake?</p>
+<h3 id="the-selection-problem">The Selection Problem</h3>
+<p>We fit several distributions to the same data. Each produces a maximized log-likelihood $\ell(\hat{\theta})$. Which model to choose?</p>
+<p>We cannot simply choose the largest $\ell(\hat{\theta})$ — more complex models always fit training data better (overfitting).</p>
+<h3 id="kl-divergence-measuring-distance-between-distributions">KL Divergence: Measuring Distance Between Distributions</h3>
+<p>The Kullback-Leibler divergence measures the "information loss" when using $q$ to approximate $p$:</p>
+<p>$$D_{KL}(p \| q) = \int p(x) \log\frac{p(x)}{q(x)} dx \geq 0$$</p>
+<p>with equality if and only if $p = q$ almost surely (proved via Jensen's inequality).</p>
+<blockquote>
+<p><strong>Intuition.</strong> <em>KL divergence is the expected surprise penalty of using the wrong model.</em> If $q$ is close to $p$, predictions are barely worse; if $q$ is far from $p$, surprise compounds across observations. AIC is, essentially, an estimator of this penalty.</p>
+</blockquote>
+<h3 id="aic-akaike-information-criterion">AIC: Akaike Information Criterion</h3>
+<p>AIC estimates the expected KL divergence, correcting the optimistic bias of training log-likelihood:</p>
+<p>$$\text{AIC} = -2\ell(\hat{\theta}) + 2k$$</p>
+<p>where $k$ is the number of parameters. Lower AIC = better model.</p>
+<p><strong>Akaike weights</strong>: $w_i = e^{-\Delta_i/2} / \sum_j e^{-\Delta_j/2}$ — the approximate probability that model $i$ is the best among candidates.</p>
+<h3 id="bic-bayesian-information-criterion">BIC: Bayesian Information Criterion</h3>
+<p>Derived from the Laplace approximation to Bayesian marginal evidence:</p>
+<p>$$\text{BIC} = -2\ell(\hat{\theta}) + k\log n$$</p>
+<p>Penalizes complexity more strongly than AIC for $n > 7$. BIC is consistent: selects the true model as $n \to \infty$.</p>
+<p><strong>Mental hook:</strong> <em>AIC for prediction, BIC for identification.</em> When they disagree, the right choice depends on the question you're answering.</p>
+<h3 id="goodness-of-fit-tests">Goodness-of-Fit Tests</h3>
+<ul>
+<li><strong>Kolmogorov-Smirnov (KS)</strong>: compares empirical CDF with theoretical. Sensitive to differences in the center.</li>
+<li><strong>Anderson-Darling (AD)</strong>: like KS, but with more weight on tails. Crucial for cost modelling where tails matter.</li>
+</ul>
+<h3 id="likelihood-ratio-test">Likelihood Ratio Test</h3>
+<p>For nested models ($M_0 \subset M_1$):</p>
+<p>$$\Lambda = -2[\ell(\hat{\theta}_0) - \ell(\hat{\theta}_1)] \xrightarrow{d} \chi^2(\Delta k)$$</p>
+<p>Reject the restricted model if $\Lambda$ exceeds the critical value.</p>
+<figure><img src="../figures/probabilistic-cost-modelling/model_comparison.png" alt="Model comparison: AIC, BIC, and Akaike weights" loading="lazy"><figcaption>Model comparison: AIC, BIC, and Akaike weights</figcaption></figure>
+<hr />
+<h2 id="mixture-models-and-multimodality">Mixture Models and Multimodality</h2>
+<p>So far each component has been treated as a single distribution. But real salary data violates this assumption immediately: a single fit to a junior/senior team mixes two populations and produces a model that represents neither. Mixture models extend the framework to handle this directly.</p>
+<h3 id="the-problem">The Problem</h3>
+<p>Salary data is often bimodal: juniors (~ R\$ 8,000) and seniors (~ R\$ 18,000) form distinct clusters. No unimodal distribution captures this structure.</p>
+<p>If we fit a single Normal, we get mean ~ R\$ 12,200 with inflated variance. **The "average employee" at R\$ 12,200 doesn't exist in either cluster — the mean is a mathematical artifact.**</p>
+<h3 id="gaussian-mixture-model-gmm">Gaussian Mixture Model (GMM)</h3>
+<p>$$f(x) = \sum_{k=1}^K \pi_k \cdot \mathcal{N}(x \mid \mu_k, \sigma_k^2)$$</p>
+<p>where $\pi_k \geq 0$, $\sum_k \pi_k = 1$ are the mixing weights.</p>
+<h3 id="the-em-algorithm">The EM Algorithm</h3>
+<p>Direct MLE fails because the log of a sum doesn't decompose. The Expectation-Maximization algorithm solves this iteratively:</p>
+<p><strong>E-step</strong>: Compute responsibilities (probability of each observation belonging to each component):</p>
+<p>$$\gamma_{ik} = \frac{\pi_k \cdot \mathcal{N}(x_i \mid \mu_k, \sigma_k^2)}{\sum_j \pi_j \cdot \mathcal{N}(x_i \mid \mu_j, \sigma_j^2)}$$</p>
+<p><strong>M-step</strong>: Update parameters using responsibilities as weights:</p>
+<p>$$\pi_k^{new} = \frac{N_k}{n}, \quad \mu_k^{new} = \frac{\sum_i \gamma_{ik} x_i}{N_k}, \quad \sigma_k^{2,new} = \frac{\sum_i \gamma_{ik}(x_i - \mu_k)^2}{N_k}$$</p>
+<p>where $N_k = \sum_i \gamma_{ik}$.</p>
+<h3 id="monotone-convergence">Monotone Convergence</h3>
+<p>EM guarantees $\ell(\theta^{(t+1)}) \geq \ell(\theta^{(t)})$ (proved via Jensen's inequality and the ELBO). Converges to a local maximum — we use multiple random restarts to mitigate.</p>
+<h3 id="choosing-k">Choosing K</h3>
+<p>We use BIC to select the number of components: fit GMMs with $K = 1, 2, 3, \ldots$ and choose the $K$ that minimizes BIC.</p>
+<h3 id="the-budget-cost-of-ignoring-bimodality">The Budget Cost of Ignoring Bimodality</h3>
+<p>In <a href="#experiment-d-mixture-detection">Experiment D</a>, ignoring bimodality and forcing a single Normal on a 60% junior / 40% senior mixture:<br />
+- Inflates the estimated standard deviation by ~40%<br />
+- Distorts VaR(95%) by R\$ 1,500–2,500 per employee<br />
+- For a 50-person team, this is R\$ 75K–125K of misallocated reserve</p>
+<p><strong>Mental hook:</strong> <em>In bimodal distributions, the average represents no one.</em></p>
+<figure><img src="../figures/probabilistic-cost-modelling/mixture_detection.png" alt="Mixture detection: GMM identifies bimodal structure" loading="lazy"><figcaption>Mixture detection: GMM identifies bimodal structure</figcaption></figure>
+<hr />
+<h2 id="heavy-tails-and-extreme-costs">Heavy Tails and Extreme Costs</h2>
+<p>Mixture models address the <em>center</em> of the distribution. But the most consequential modelling errors live in the <em>tails</em> — the rare-but-catastrophic events where budgets actually break. This section is the core of the article.</p>
+<h3 id="the-practical-climax">The Practical Climax</h3>
+<p><strong>If you use a Normal distribution for severance costs, you are systematically under-reserving. This is not an opinion. It is a mathematical fact.</strong></p>
+<h3 id="light-vs-heavy-formal-definition">Light vs Heavy: Formal Definition</h3>
+<p>A distribution is <strong>light-tailed</strong> if its moment generating function exists for some $t > 0$: $M_X(t) = E[e^{tX}] < \infty$. Equivalently, $P(X > x)$ decays at least exponentially.</p>
+<p>A distribution is <strong>heavy-tailed</strong> if $M_X(t) = \infty$ for all $t > 0$. The survival function decays slower than any exponential.</p>
+<h3 id="pareto-tail-behaviour">Pareto Tail Behaviour</h3>
+<p>For $X \sim \text{Pareto}(\alpha, x_m)$:</p>
+<p>$$P(X > x) = \left(\frac{x_m}{x}\right)^\alpha$$</p>
+<p>This decays <strong>polynomially</strong>. Compare with the Normal, which decays as $e^{-x^2/2}$ (super-exponentially).</p>
+<p><strong>Tail thinning ratio:</strong><br />
+- Pareto: $P(X > 2c) / P(X > c) = 2^{-\alpha}$ (constant!)<br />
+- Normal: the same ratio decays exponentially</p>
+<blockquote>
+<p><strong>Mental hook.</strong> <em>Tail risk is where budgets fail, not where averages live.</em> In a Normal world, doubling the threshold makes the event astronomically rarer. In a Pareto world, doubling the threshold reduces the probability by a fixed factor — independent of where you started.</p>
+</blockquote>
+<h3 id="hill-estimator">Hill Estimator</h3>
+<p>To estimate the tail index $\alpha$ from data:</p>
+<p>$$\hat{\alpha}_{Hill} = \left[\frac{1}{k}\sum_{i=1}^k \log\frac{X_{(n-i+1)}}{X_{(n-k)}}\right]^{-1}$$</p>
+<p>Based on the $k$ largest observed values. Plot $\hat{\alpha}$ vs $k$ and look for a stable region.</p>
+<h3 id="budget-impact-the-catastrophic-underestimation">Budget Impact: The Catastrophic Underestimation</h3>
+<p>Severance costs: Pareto($\alpha = 2.5$, $x_m = 10,000$) vs moment-matched Normal:</p>
+<table>
+<thead>
+<tr>
+<th>Metric</th>
+<th>Pareto</th>
+<th>Normal</th>
+<th>Ratio</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$P(X > 50,000)$</td>
+<td>1.79%</td>
+<td>0.013%</td>
+<td><strong>138x</strong></td>
+</tr>
+<tr>
+<td>$P(X > 100,000)$</td>
+<td>0.032%</td>
+<td>$\approx 0$</td>
+<td><strong>&gt;1000x</strong></td>
+</tr>
+<tr>
+<td>ES(99%)</td>
+<td>R\$ 105,160 | R\$ 55,297</td>
+<td><strong>1.9x</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+<p><strong>The executive translation:</strong> the Normal model says a R\$ 50,000 severance event happens once in 77,000 cases. The Pareto says it happens once in 56 cases. <em>This is why a single layoff round can blow up a quarter's budget.</em></p>
+<h3 id="value-at-risk-var-and-expected-shortfall-es">Value at Risk (VaR) and Expected Shortfall (ES)</h3>
+<p><strong>VaR</strong> at level $p$: the $p$-th quantile. "We are $p$% confident cost won't exceed VaR."</p>
+<p><strong>ES</strong> (CVaR): the average loss given it exceeded VaR. "If costs exceed VaR, how bad is it on average?"</p>
+<p>For the Pareto: $\text{ES}_p = \frac{\alpha}{\alpha - 1} \cdot \text{VaR}_p$ — always a fixed multiple of VaR.</p>
+<figure><img src="../figures/probabilistic-cost-modelling/tail_risk_comparison.png" alt="Tail risk comparison: Normal vs Pareto" loading="lazy"><figcaption>Tail risk comparison: Normal vs Pareto</figcaption></figure>
+<hr />
+<h2 id="experiments-and-results">Experiments and Results</h2>
+<p>The theory above predicts specific consequences. This section tests those predictions through controlled experiments. Each experiment isolates one claim, runs it on synthetic data with known ground truth, and measures the gap between correct and incorrect modelling.</p>
+<h3 id="why-synthetic-data">Why Synthetic Data?</h3>
+<p>Every experiment in this article uses synthetic data generated from known distributions. This is a deliberate choice, not a limitation:</p>
+<ul>
+<li><strong>Ground truth control:</strong> we know exactly which distribution generated the data, so we can measure how well each candidate model recovers it. With real data, the "true" model is unknown.</li>
+<li><strong>Reproducibility:</strong> every experiment uses fixed random seeds. Anyone can re-run the code and obtain identical figures and numbers.</li>
+<li><strong>Effect isolation:</strong> by changing one parameter at a time (sample size, true distribution, mixture composition), we attribute observed effects to specific causes — not to data quality, NDA-induced noise, or sampling artifacts.</li>
+</ul>
+<p>This trades external validity (will it work on <em>your</em> HR system data?) for internal validity (does the framework do what it claims?). The companion repository documents how to apply the same pipeline to real data.</p>
+<h3 id="experiment-a-the-distribution-zoo">Experiment A — The Distribution Zoo</h3>
+<p><strong>Claim.</strong> Distribution families fitted to the same right-skewed data disagree most where it matters: the tail.</p>
+<p><strong>Setup.</strong> $n = 2{,}000$ samples from LogNormal($\mu = 9.1$, $\sigma = 0.4$); Normal, LogNormal, Gamma, and Weibull fitted via MLE; fitted PDFs overlaid on the empirical histogram.</p>
+<p><strong>Result.</strong> LogNormal captures the skewness; Normal misfits both peak and tail; Gamma and Weibull approximate the bulk but underestimate the right tail.</p>
+<p><strong>Connection.</strong> Confirms the shape vocabulary of <a href="#distribution-families">Distribution Families</a>: support and tail behaviour, not the mean, are what separate the candidates.</p>
+<h3 id="experiment-b-mle-convergence">Experiment B — MLE Convergence</h3>
+<p><strong>Claim.</strong> MLE is consistent and its error decays as $1/\sqrt{n}$, exactly as the asymptotic theory predicts.</p>
+<p><strong>Setup.</strong> 200 replications at each $n \in \{20, 50, 100, \ldots, 10{,}000\}$, fitting LogNormal($9.1, 0.4$); empirical mean and standard deviation of $\hat{\mu}$ compared with the theoretical SE $= \sigma / \sqrt{n}$.</p>
+<p><strong>Result.</strong> Estimates converge to the true parameter; the empirical SD matches the theoretical $1/\sqrt{n}$ decay across three orders of magnitude.</p>
+<p><strong>Connection.</strong> Empirical confirmation of the asymptotic normality result in <a href="#maximum-likelihood-estimation">Maximum Likelihood Estimation</a>.</p>
+<h3 id="experiment-c-the-cost-of-the-wrong-distribution">Experiment C — The Cost of the Wrong Distribution</h3>
+<p><strong>Claim.</strong> Fitting a Normal to LogNormal cost data systematically underestimates tail probabilities — and therefore the reserve.</p>
+<p><strong>Setup.</strong> $n = 1{,}000$ generated from LogNormal; Normal and LogNormal fitted; 200K samples simulated from each fitted model; $P(\text{cost} > \text{ceiling})$ at multiples of the mean, plus VaR(99%) and ES(99%), compared.</p>
+<p><strong>Result.</strong> Normal underestimates $P(X > 2 \cdot \text{mean})$ by ~3x and $P(X > 3 \cdot \text{mean})$ by ~8x. For a 50-person team, this translates to R\$ 100K–150K of insufficient reserve.</p>
+<p><strong>Connection.</strong> Puts numbers on the salary-component gap promised in <a href="#whats-at-stake">What's at Stake</a>.</p>
+<figure><img src="../figures/probabilistic-cost-modelling/wrong_distribution_impact.png" alt="Impact of the wrong distribution on budget" loading="lazy"><figcaption>Impact of the wrong distribution on budget</figcaption></figure>
+<h3 id="experiment-d-mixture-detection">Experiment D — Mixture Detection</h3>
+<p><strong>Claim.</strong> GMM with BIC selection recovers hidden bimodal structure that any single-family fit misses.</p>
+<p><strong>Setup.</strong> 60% sampled from $N(8000, 1500^2)$, 40% from $N(18000, 2500^2)$; GMMs fitted with $K \in \{1, 2, 3, 4\}$; BIC compared across $K$; recovered weights, means, and standard deviations inspected.</p>
+<p><strong>Result.</strong> BIC strongly favors $K = 2$. Recovered parameters are within 5% of true values. The single-Normal fit produces a mean that represents no actual employee.</p>
+<p><strong>Connection.</strong> Validates the EM + BIC procedure of <a href="#mixture-models-and-multimodality">Mixture Models and Multimodality</a>.</p>
+<h3 id="experiment-e-heavy-tail-risk">Experiment E — Heavy Tail Risk</h3>
+<p><strong>Claim.</strong> At matched mean and variance, Pareto and Normal disagree by orders of magnitude in the tail.</p>
+<p><strong>Setup.</strong> Pareto($\alpha = 2.5$, $x_m = 10{,}000$) vs moment-matched Normal at $\mu = 16{,}667$, $\sigma = 14{,}907$; $P(X > x)$ at thresholds R\$ 30K to R\$ 200K; analytical VaR and ES at 90%, 95%, 99%.</p>
+<p><strong>Result.</strong> Normal underestimates $P(X > 50K)$ by 138x, and ES(99%) by ~1.9x. The "rare event" under Normal is a routine one under Pareto — the headline gap of this article.</p>
+<p><strong>Connection.</strong> The polynomial-vs-exponential tail decay derived in <a href="#heavy-tails-and-extreme-costs">Heavy Tails and Extreme Costs</a>, made numerical.</p>
+<h3 id="experiment-f-model-comparison">Experiment F — Model Comparison</h3>
+<p><strong>Claim.</strong> AIC, BIC, and goodness-of-fit tests jointly identify the true distribution.</p>
+<p><strong>Setup.</strong> $n = 500$ from LogNormal; all five candidates fitted; Akaike weights, BIC ranking, and KS p-values computed.</p>
+<p><strong>Result.</strong> LogNormal wins with Akaike weight &gt; 96%. Normal is decisively rejected. The KS test confirms LogNormal is the only candidate that passes goodness-of-fit.</p>
+<p><strong>Connection.</strong> The selection machinery of <a href="#model-comparison">Model Comparison</a> working end to end on data with known ground truth.</p>
+<h3 id="experiment-g-end-to-end-pipeline">Experiment G — End-to-End Pipeline</h3>
+<p><strong>Claim.</strong> The full workflow selects the right family per component and prices the budget impact automatically.</p>
+<p><strong>Setup.</strong> Synthetic 50-person team (salary, overtime, severance, and hiring data); all candidates fitted to each component; ranking via AIC/BIC; resulting VaR and reserve computed.</p>
+<p><strong>Result.</strong> The pipeline correctly identifies LogNormal for salary and Pareto for severance. The total reserve at 99% differs by R\$ 100K–150K from the Normal-baseline estimate.</p>
+<p><strong>Connection.</strong> A dry run of the five-step procedure condensed in <a href="#a-practical-framework">A Practical Framework</a>.</p>
+<figure><img src="../figures/probabilistic-cost-modelling/full_pipeline.png" alt="End-to-end pipeline: data → fit → select → budget impact" loading="lazy"><figcaption>End-to-end pipeline: data → fit → select → budget impact</figcaption></figure>
+<hr />
+<h2 id="a-practical-framework">A Practical Framework</h2>
+<p>The theory and experiments above point to a concrete decision procedure. This section condenses everything into a five-step workflow that any analyst can apply to their own data.</p>
+<h3 id="decision-tree-for-distribution-selection">Decision Tree for Distribution Selection</h3>
+<p><strong>Step 1: Visualize</strong><br />
+- Histogram + Q-Q plot<br />
+- Is the data skewed? Multimodal? Are there extreme values?</p>
+<p><strong>Step 2: Fit candidates</strong><br />
+- Use MLE to fit 3-5 distribution families<br />
+- Check convergence and parameter reasonableness</p>
+<p><strong>Step 3: Compare</strong><br />
+- Compute AIC and BIC for all candidates<br />
+- Compute Akaike weights — is there a clear winner?<br />
+- Use AIC for prediction, BIC for identifying the "true" model</p>
+<p><strong>Step 4: Validate</strong><br />
+- Goodness-of-fit test (Anderson-Darling for tails)<br />
+- Q-Q plot of the winning model<br />
+- Does the winning model actually fit well?</p>
+<p><strong>Step 5: Quantify impact</strong><br />
+- Compute VaR and ES under the selected model<br />
+- Compare with what Normal would have predicted<br />
+- Translate the difference into R\$ of budget reserve</p>
+<h3 id="common-pitfalls">Common Pitfalls</h3>
+<ol>
+<li><strong>Using Normal by default</strong> → systematically underestimates tails</li>
+<li><strong>Ignoring multimodality</strong> → inflated variance, meaningless mean</li>
+<li><strong>Looking only at the mean</strong> → ignores all shape information</li>
+<li><strong>Small sample</strong> → use AICc, not AIC</li>
+<li><strong>Not validating</strong> → the model with best AIC may still not fit well</li>
+</ol>
+<h3 id="minimum-viable-implementation">Minimum Viable Implementation</h3>
+<p>If you have one afternoon and one dataset, here is the shortest path to value:</p>
+<ol>
+<li><strong>Fit two models:</strong> LogNormal (for skewed positive data) and Pareto (for tail-heavy data).</li>
+<li><strong>Compare via AIC:</strong> the lower wins. If close, pick LogNormal for simplicity.</li>
+<li><strong>Compute VaR(95%) and VaR(99%)</strong> under the winner.</li>
+<li><strong>Compute the same under a Normal fit.</strong></li>
+<li><strong>Report the delta.</strong> That number is the under-reservation if Normal had been your default.</li>
+</ol>
+<p>This five-step path covers most real cost-modelling decisions. The full framework only adds rigor where the data demands it.</p>
+<hr />
+<h2 id="limitations">Limitations</h2>
+<p>The framework above is deliberately scoped. The following limitations are not failures of the method — they are boundaries within which it operates.</p>
+<p><strong>Sample size sensitivity.</strong> With $n < 50$, MLE estimates are noisy and AIC can pick the wrong model with non-trivial probability. AICc helps but doesn't eliminate the issue. For small teams or short-history data, parametric bootstrap is recommended over asymptotic confidence intervals.</p>
+<p><strong>Model risk persists.</strong> Choosing the best of five candidates does not guarantee any of them is correct. Goodness-of-fit tests guard against gross misspecification but cannot detect a sixth, unconsidered family. The framework reduces model risk; it does not eliminate it.</p>
+<p><strong>Independence assumption.</strong> Each cost component is modelled independently. In reality, components are correlated: a wave of layoffs simultaneously reduces hiring costs and inflates severance. Modelling these dependencies requires multivariate methods (copulas, joint distributions) covered in the companion article <a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a>.</p>
+<p><strong>Static distributions.</strong> This article assumes distributions are stable over time. Salary distributions drift with inflation, market shifts, and organizational changes. Time-series methods (state-space models, regime-switching) are out of scope.</p>
+<p><strong>Real-world data complications.</strong> Synthetic data is clean. Real HR data has censoring (employees still active when measured), truncation (only severance above a legal minimum is recorded), missing data, and reporting noise. The framework applies, but pre-processing matters.</p>
+<p><strong>Decision context omitted.</strong> A "better model" by AIC is not always a better business decision. Risk appetite, regulatory capital, and stakeholder conservatism may push toward the Normal even when it fits worse — because its outputs are more familiar. The framework informs the decision; it does not replace it.</p>
+<hr />
+<h2 id="conclusion">Conclusion</h2>
+<h3 id="the-distribution-is-the-model">The Distribution Is the Model</h3>
+<p>The distributional assumption is not a technical detail — it is the most important modelling decision a cost analyst makes. Every downstream calculation (mean, variance, confidence intervals, reserves) inherits this choice.</p>
+<h3 id="key-takeaways">Key Takeaways</h3>
+<ol>
+<li>
+<p><strong>People costs are structurally non-Normal</strong>: right-skewed (LogNormal), heavy-tailed (Pareto), and often multimodal (GMM). The Normal is the exception, not the rule.</p>
+</li>
+<li>
+<p><strong>MLE provides the principled framework</strong> for fitting: optimal parameters, automatic standard errors, and a solid theoretical basis for comparison via AIC/BIC.</p>
+</li>
+<li>
+<p><strong>The impact of getting it wrong is measurable and substantial</strong>: the Normal underestimates the probability of extreme costs by factors of 100x or more. For a 50-person team, this can represent hundreds of thousands of R\$ in insufficient reserves.</p>
+</li>
+</ol>
+<h3 id="next-steps">Next Steps</h3>
+<p>This article establishes the distributional selection framework. The companion article <a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a> shows how to use these distributions to simulate total team cost, including correlations between components and scenario analysis.</p>
+<hr />
+<h2 id="references">References</h2>
+<ul>
+<li>Casella, G. &amp; Berger, R. (2002). <em>Statistical Inference</em>. Duxbury.</li>
+<li>Burnham, K. &amp; Anderson, D. (2002). <em>Model Selection and Multimodel Inference</em>. Springer.</li>
+<li>Bishop, C. (2006). <em>Pattern Recognition and Machine Learning</em>. Springer.</li>
+<li>Embrechts, P., Klüppelberg, C. &amp; Mikosch, T. (1997). <em>Modelling Extremal Events</em>. Springer.</li>
+<li>McLachlan, G. &amp; Peel, D. (2000). <em>Finite Mixture Models</em>. Wiley.</li>
+</ul>
+<hr />
+<p><em>All figures and numbers in this article are reproduced by versioned scripts with fixed seeds in the <a href="https://github.com/brunoramosmartins/probabilistic-cost-modelling-article">companion repository</a>. See the repository README for how to run them.</em></p>
+          
+        </article>
+
+        <!-- On This Page — populated by articleToc.js from heading ids -->
+        <aside class="article-toc" aria-label="On this page">
+          <nav class="article-toc__inner">
+            <p class="article-toc__title">On this page</p>
+            <ul class="article-toc__list" id="article-toc-list"></ul>
+          </nav>
+        </aside>
+
+      </div>
+
+    </div>
+  </main>
+
+  <!-- =========================================================
+       FOOTER
+  ========================================================== -->
+  <footer class="site-footer" role="contentinfo">
+    <div class="container container--wide">
+      <span class="footer-copy">© 2026 Bruno Ramos Martins</span>
+      <nav class="footer-links" aria-label="Footer navigation">
+        <a href="https://github.com/brunoramosmartins" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://www.linkedin.com/in/bruno-ramos-martins-22a6a61a0/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+        <a href="../about.html">About</a>
+      </nav>
+    </div>
+  </footer>
+
+  <!-- Nav toggle script -->
+  <script src="../assets/js/navigation.js" defer></script>
+  <!-- On This Page panel + heading anchors + scroll spy -->
+  <script src="../assets/js/articleToc.js" defer></script>
+
+</body>
+</html>

--- a/templates/article_template.html
+++ b/templates/article_template.html
@@ -179,8 +179,9 @@
 
     .article-toc__inner {
       position: sticky;
-      top: var(--space-8);
-      max-height: calc(100vh - var(--space-16));
+      /* clear the fixed site header, plus breathing room */
+      top: calc(var(--header-height) + var(--space-6));
+      max-height: calc(100vh - var(--header-height) - var(--space-12));
       overflow-y: auto;
       padding-left: var(--space-4);
       border-left: 1px solid var(--color-border);


### PR DESCRIPTION
- Editorial pass (WRITING-GUIDE) applied to The Shape of What You'll Spend and Why Your Budget Never Hits the Exact Number: orientation blocks, unnumbered sections with named anchor cross-references, Claim/Setup/Result/Connection experiments, linked companions, reproducibility footers
- Both published together so the mutual cross-links resolve
- Fix: On This Page panel now offsets below the fixed site header (title was hidden on scroll)
- Closes the first two editorial issues of the v0.9 milestone