### PR TITLE
fix: remove forced line breaks (nl2br) and escape monte-carlo currency

### DIFF
--- a/WRITING-GUIDE.md
+++ b/WRITING-GUIDE.md
@@ -170,7 +170,11 @@ and experiment is the house signature.
 - Include a Notation table only when the symbol load is heavy (roughly:
   more than ~10 recurring symbols). Place it immediately after the
   orientation block, wrapped in `<details><summary>Notation</summary>…</details>`.
-- Currency: `R$ 50,000` in prose; `R\$\,50{,}000` inside math mode.
+- **Currency: always escape the dollar sign as `\$`** — `R\$ 50{,}000` in
+  prose, `R\$\,50{,}000` inside math. MathJax treats `$` as a math
+  delimiter everywhere on the page, so a bare `R$ 50,000` opens a spurious
+  math span that swallows text up to the next `$` and renders as garbled
+  math. This applies to US dollars too (`\$500`, not `$500`).
 
 ### Limitations
 

--- a/build_blog.py
+++ b/build_blog.py
@@ -384,7 +384,7 @@ def build_article(md_path: Path, templates: dict[str, str], dry_run: bool = Fals
 
     html_body = markdown.markdown(
         protected_body,
-        extensions=["fenced_code", "codehilite", "tables", "toc", "nl2br"],
+        extensions=["fenced_code", "codehilite", "tables", "toc"],
         extension_configs={
             "codehilite": {"css_class": "highlight", "guess_lang": False},
         },

--- a/markdown_posts/monte-carlo-budget.md
+++ b/markdown_posts/monte-carlo-budget.md
@@ -63,7 +63,7 @@ A point estimate gives you a number. A distribution gives you the **policy**: ho
 
 ### What Changes With a Distribution
 
-This article replaces the single number with a **probability distribution**. Using Monte Carlo simulation grounded in the Law of Large Numbers and the Central Limit Theorem, we transform "we expect to spend R$ 11.5M" into "we are 90% confident spending will fall between R$ 10.7M and R$ 12.4M, with a 3% probability of exceeding the ceiling."
+This article replaces the single number with a **probability distribution**. Using Monte Carlo simulation grounded in the Law of Large Numbers and the Central Limit Theorem, we transform "we expect to spend R\$ 11.5M" into "we are 90% confident spending will fall between R\$ 10.7M and R\$ 12.4M, with a 3% probability of exceeding the ceiling."
 
 > **A budget is a distribution, not a number.** This single shift changes how budgets are *approved*, not just how they are *calculated*. The output is no longer a target — it is a risk profile that a CFO can underwrite.
 
@@ -81,7 +81,7 @@ $$
 \hat{X} = \sum_{k} (\text{quantity}_k \times \text{unit cost}_k) + \text{contingency}
 $$
 
-The result is a number — say, R$ 11.5 million. But this number is $E[X_{\text{total}}]$: the expected value of a random variable. It tells us the centre of the distribution. What it discards is everything else:
+The result is a number — say, R\$ 11.5 million. But this number is $E[X_{\text{total}}]$: the expected value of a random variable. It tells us the centre of the distribution. What it discards is everything else:
 
 - **Variance:** How spread out are the possible outcomes?
 - **Skewness:** Is the distribution symmetric, or could costs be pulled higher by a few extreme events?
@@ -420,11 +420,11 @@ Always. Stratification removes between-strata variance.
 
 A 30× variance reduction sounds like a mathematical curiosity. It is a **compute and response-time** result.
 
-Suppose the naive simulation needs $N = 30{,}000$ runs to deliver a ±R$ 50K confidence interval. With control variates, the same precision lands at $N = 1{,}000$. Translating into engineering reality:
+Suppose the naive simulation needs $N = 30{,}000$ runs to deliver a ±R\$ 50K confidence interval. With control variates, the same precision lands at $N = 1{,}000$. Translating into engineering reality:
 
 | Aspect | Naive MC | With Control Variates | Practical Implication |
 |--------|---------|----------------------|----------------------|
-| Runs to ±R$ 50K CI | 30,000 | 1,000 | 30× fewer scenarios |
+| Runs to ±R\$ 50K CI | 30,000 | 1,000 | 30× fewer scenarios |
 | Wall-clock on a laptop | ~18 s | ~0.6 s | **Real-time interactive update** |
 | Cloud cost per refresh | ~30 vCPU-seconds | ~1 vCPU-second | Negligible per query |
 | Suitable for dashboard | No (too slow) | Yes | A CFO can rerun during a board meeting |
@@ -508,7 +508,7 @@ Each experiment follows the same template — **Claim**, **Setup**, **Result**, 
 
 **Setup.** 10 independent runs of LogNormal salary draws, $N$ from 1 to 10,000 each; absolute deviation $|\bar{X}_n - E[X]|$ tracked across runs, with the Chebyshev 95% band overlaid.
 
-**Result.** At small $N$, runs spread widely; by $N = 5{,}000$, all 10 runs cluster within R$ 200 of the analytical mean. The empirical decay matches $\sigma/\sqrt{n}$ on a log-log plot.
+**Result.** At small $N$, runs spread widely; by $N = 5{,}000$, all 10 runs cluster within R\$ 200 of the analytical mean. The empirical decay matches $\sigma/\sqrt{n}$ on a log-log plot.
 
 **Connection.** The Weak Law proved in [The Law of Large Numbers](#the-law-of-large-numbers), observed at finite $N$ (the figure lives in that section).
 
@@ -526,9 +526,9 @@ Each experiment follows the same template — **Claim**, **Setup**, **Result**, 
 
 **Claim.** Monte Carlo recovers the full distribution of $X_{\text{total}}$ — not just its mean — including the ceiling-breach probability no point estimate can produce.
 
-**Setup.** $N = 50{,}000$ iterations of the IT headcount budget model with default parameters, seed 42; ceiling at R$ 12.5M; metrics: relative error of the MC mean vs analytical $E[X]$, 95% CI half-width, P5–P95 range, $P(X \gt \text{ceiling})$.
+**Setup.** $N = 50{,}000$ iterations of the IT headcount budget model with default parameters, seed 42; ceiling at R\$ 12.5M; metrics: relative error of the MC mean vs analytical $E[X]$, 95% CI half-width, P5–P95 range, $P(X \gt \text{ceiling})$.
 
-**Result.** MC mean within 0.1% of analytical. 95% CI half-width approximately R$ 4K. P5–P95 spans ~R$ 1.6M. The probability of exceeding R$ 12.5M is approximately 3%. The distribution is right-skewed.
+**Result.** MC mean within 0.1% of analytical. 95% CI half-width approximately R\$ 4K. P5–P95 spans ~R\$ 1.6M. The probability of exceeding R\$ 12.5M is approximately 3%. The distribution is right-skewed.
 
 **Connection.** Instantiates the full model of [Budget Components as Random Variables](#budget-components-as-random-variables) and delivers the risk profile promised in [The Point Estimate Problem](#the-point-estimate-problem).
 
@@ -562,11 +562,11 @@ Each experiment follows the same template — **Claim**, **Setup**, **Result**, 
 
 | Metric | Value |
 |--------|-------|
-| Analytical $E[X]$ | R$ 11.55M |
+| Analytical $E[X]$ | R\$ 11.55M |
 | MC mean (N=50K) | Within 0.1% of analytical |
-| 95% CI half-width (N=50K) | ~R$ 4K |
-| P5–P95 range | ~R$ 1.6M |
-| P(X exceeds R$ 12.5M) | ~3% |
+| 95% CI half-width (N=50K) | ~R\$ 4K |
+| P5–P95 range | ~R\$ 1.6M |
+| P(X exceeds R\$ 12.5M) | ~3% |
 | Most sensitive parameter | Dominant component's mean |
 | Best variance reduction | Control variates (~30× variance, ~5–6× CI width) |
 
@@ -623,15 +623,15 @@ The single highest-leverage moment in this whole article is the language a budge
 
 > **Before — point estimate:**
 >
-> *"The budget for next year is R$ 11.55M."*
+> *"The budget for next year is R\$ 11.55M."*
 >
 > A target. No risk attached. Every variance reads as a miss.
 
 > **After — distribution + policy:**
 >
-> *"We are 95% confident the cost will fall between R$ 10.7M and R$ 12.4M, with a mean of R$ 11.55M.*
+> *"We are 95% confident the cost will fall between R\$ 10.7M and R\$ 12.4M, with a mean of R\$ 11.55M.*
 >
-> *We propose to reserve R$ 12.0M as the planned budget (P90), with an additional R$ 500K of risk capital available if needed (P99). The probability of exceeding R$ 12.5M is approximately 3%. The primary driver of uncertainty is [dominant component] — investing in better salary forecasts will tighten the range more than any other action."*
+> *We propose to reserve R\$ 12.0M as the planned budget (P90), with an additional R\$ 500K of risk capital available if needed (P99). The probability of exceeding R\$ 12.5M is approximately 3%. The primary driver of uncertainty is [dominant component] — investing in better salary forecasts will tighten the range more than any other action."*
 >
 > A risk profile leadership can underwrite. Variances read against the *interval*, not the mean.
 

--- a/posts/bayesian-fyf.html
+++ b/posts/bayesian-fyf.html
@@ -279,59 +279,59 @@
 </blockquote>
 <hr />
 <h2 id="the-forecast-that-learns">The Forecast That Learns</h2>
-<p>Every budget analyst lives the same calendar. December: a plan is<br />
-approved. April, July, October, January-of-next-year: a Forecast<br />
-Year-end Financial (FYF) review revises the plan against year-to-date<br />
-actuals. The revisions are quarterly; the questions are perennial.<br />
-<em>By how much should I move the forecast? How tight is my new estimate?<br />
+<p>Every budget analyst lives the same calendar. December: a plan is
+approved. April, July, October, January-of-next-year: a Forecast
+Year-end Financial (FYF) review revises the plan against year-to-date
+actuals. The revisions are quarterly; the questions are perennial.
+<em>By how much should I move the forecast? How tight is my new estimate?
 What is the chance of breaching the budget ceiling by year-end?</em></p>
-<p>The traditional answer treats each revision as a fresh estimate. The<br />
-analyst stares at year-to-date actuals, mentally weighs them against<br />
-the plan, and produces a new number. The new number is then defended<br />
-in a meeting; the defence is usually qualitative; the weight chosen<br />
+<p>The traditional answer treats each revision as a fresh estimate. The
+analyst stares at year-to-date actuals, mentally weighs them against
+the plan, and produces a new number. The new number is then defended
+in a meeting; the defence is usually qualitative; the weight chosen
 is rarely auditable.</p>
-<p>This article argues that the FYF cycle is, in a precise mathematical<br />
-sense, <strong>sequential Bayesian updating</strong>. The plan is a <em>prior</em>. The<br />
-actuals are <em>data</em>. The revised forecast is a <em>posterior</em>. This is<br />
-not analogy; it is identity. And recognising the identity turns three<br />
+<p>This article argues that the FYF cycle is, in a precise mathematical
+sense, <strong>sequential Bayesian updating</strong>. The plan is a <em>prior</em>. The
+actuals are <em>data</em>. The revised forecast is a <em>posterior</em>. This is
+not analogy; it is identity. And recognising the identity turns three
 qualitative pain-points into closed-form results:</p>
 <ol>
-<li><em>How do I weight the plan against the data?</em> — The<br />
-<strong>precision-weighted mean</strong> of the Normal–Normal posterior. The<br />
- weights are not a matter of judgement: they are functions of the<br />
+<li><em>How do I weight the plan against the data?</em> — The
+ <strong>precision-weighted mean</strong> of the Normal–Normal posterior. The
+ weights are not a matter of judgement: they are functions of the
  stated prior uncertainty and the per-month observation noise.</li>
-<li><em>How tight is my forecast?</em> — The posterior variance shrinks<br />
- monotonically with each new month.<br />
-<a href="#sequential-updating-and-shrinkage">Sequential Updating and Shrinkage</a><br />
+<li><em>How tight is my forecast?</em> — The posterior variance shrinks
+ monotonically with each new month.
+ <a href="#sequential-updating-and-shrinkage">Sequential Updating and Shrinkage</a>
  makes this "monotonically" both rigorous and quantitative.</li>
-<li><em>What is the probability of ending the year over budget?</em> — The<br />
- posterior <strong>predictive</strong> distribution applied to the unobserved<br />
+<li><em>What is the probability of ending the year over budget?</em> — The
+ posterior <strong>predictive</strong> distribution applied to the unobserved
  months gives an exact closed form, not a heuristic.</li>
 </ol>
-<p>The route from claim to proof is short.<br />
-<a href="#bayes-theorem-for-budget-analysts">Bayes' Theorem for Budget Analysts</a><br />
-derives the continuous theorem and clarifies the difference between<br />
-credible and confidence intervals.<br />
-<a href="#conjugate-families">Conjugate Families</a> develops the four<br />
-prior–likelihood pairs that cover the FYF cost model.<br />
-<a href="#sequential-updating-and-shrinkage">Sequential Updating and Shrinkage</a><br />
-chains conjugate updates across the year and proves that sequential and<br />
-batch updating produce identical posteriors.<br />
-<a href="#the-posterior-predictive">The Posterior Predictive</a> layers on top what<br />
-the CFO actually wants. <a href="#the-fyf-model">The FYF Model</a> wires the<br />
-machinery into a complete annual cycle of a 50-person IT-headcount<br />
-budget; the <a href="#experiments-and-results">experiments</a> validate it; and<br />
-<a href="#diagnostics">Diagnostics</a> supplies the checks that decide when the<br />
+<p>The route from claim to proof is short.
+<a href="#bayes-theorem-for-budget-analysts">Bayes' Theorem for Budget Analysts</a>
+derives the continuous theorem and clarifies the difference between
+credible and confidence intervals.
+<a href="#conjugate-families">Conjugate Families</a> develops the four
+prior–likelihood pairs that cover the FYF cost model.
+<a href="#sequential-updating-and-shrinkage">Sequential Updating and Shrinkage</a>
+chains conjugate updates across the year and proves that sequential and
+batch updating produce identical posteriors.
+<a href="#the-posterior-predictive">The Posterior Predictive</a> layers on top what
+the CFO actually wants. <a href="#the-fyf-model">The FYF Model</a> wires the
+machinery into a complete annual cycle of a 50-person IT-headcount
+budget; the <a href="#experiments-and-results">experiments</a> validate it; and
+<a href="#diagnostics">Diagnostics</a> supplies the checks that decide when the
 model is to be trusted and when its mechanical answer is misleading.</p>
 <hr />
 <h2 id="bayes-theorem-for-budget-analysts">Bayes' Theorem for Budget Analysts</h2>
-<p>Let $X$ denote observed data and $\theta$ an unknown parameter,<br />
-both treated as random variables. The <strong>product rule for densities</strong><br />
+<p>Let $X$ denote observed data and $\theta$ an unknown parameter,
+both treated as random variables. The <strong>product rule for densities</strong>
 factorises the joint two ways:</p>
 <p>$$
 f(x, \theta) = f(x \mid \theta) \pi(\theta) = \pi(\theta \mid x) f(x).
 $$</p>
-<p>Equating and solving for the second factor gives <strong>Bayes' theorem<br />
+<p>Equating and solving for the second factor gives <strong>Bayes' theorem
 for continuous parameters</strong>:</p>
 <p>$$
 \boxed{\quad
@@ -340,17 +340,17 @@ for continuous parameters</strong>:</p>
 f(x) = \int f(x \mid \theta) \pi(\theta) \mathrm d\theta.
 \quad}
 $$</p>
-<p>The four objects have names. $\pi(\theta)$ is the <strong>prior</strong>; in FYF,<br />
-the budget plan expressed as a distribution. $f(x \mid \theta)$ is<br />
-the <strong>sampling density</strong>, viewed as a function of $\theta$ for fixed<br />
-$x$ it is the <strong>likelihood</strong>. $f(x)$ is the <strong>marginal likelihood</strong><br />
-or evidence — the probability of the data averaged over the prior.<br />
+<p>The four objects have names. $\pi(\theta)$ is the <strong>prior</strong>; in FYF,
+the budget plan expressed as a distribution. $f(x \mid \theta)$ is
+the <strong>sampling density</strong>, viewed as a function of $\theta$ for fixed
+$x$ it is the <strong>likelihood</strong>. $f(x)$ is the <strong>marginal likelihood</strong>
+or evidence — the probability of the data averaged over the prior.
 $\pi(\theta \mid x)$ is the <strong>posterior</strong>: the revised forecast.</p>
-<p>Because $f(x)$ does not involve $\theta$, the proportional form<br />
-$\pi(\theta \mid x) \propto f(x \mid \theta) \pi(\theta)$ is<br />
-operationally enough. In conjugate families we recognise the<br />
-kernel of the right-hand side as that of a known distribution and<br />
-read off the hyperparameters; the marginal likelihood is implied by<br />
+<p>Because $f(x)$ does not involve $\theta$, the proportional form
+$\pi(\theta \mid x) \propto f(x \mid \theta) \pi(\theta)$ is
+operationally enough. In conjugate families we recognise the
+kernel of the right-hand side as that of a known distribution and
+read off the hyperparameters; the marginal likelihood is implied by
 the family and never has to be integrated.</p>
 <h3 id="point-summaries">Point summaries</h3>
 <p>When a number is required:</p>
@@ -359,66 +359,66 @@ the family and never has to be integrated.</p>
 <li><strong>Posterior mean</strong>: $\hat\theta_{\text{PM}} = \mathbb E[\theta \mid x]$.</li>
 <li><strong>Posterior median</strong>.</li>
 </ul>
-<p>For symmetric unimodal posteriors (every Normal posterior in this<br />
-article) the three coincide. For a uniform prior the MAP equals the<br />
-maximum-likelihood estimator: a flat prior produces the classical<br />
-point estimate, but with a credible-interval interpretation that<br />
+<p>For symmetric unimodal posteriors (every Normal posterior in this
+article) the three coincide. For a uniform prior the MAP equals the
+maximum-likelihood estimator: a flat prior produces the classical
+point estimate, but with a credible-interval interpretation that
 remains different from a confidence interval — see below.</p>
 <h3 id="credible-intervals-vs-confidence-intervals">Credible intervals vs confidence intervals</h3>
-<p>A <strong>$100(1-\alpha)\%$ credible interval</strong> for $\theta$ is any subset<br />
-$C$ with $\Pr(\theta \in C \mid x) = 1 - \alpha$. The most-used choice<br />
-is the equal-tailed interval bounded by the $\alpha/2$ and<br />
+<p>A <strong>$100(1-\alpha)\%$ credible interval</strong> for $\theta$ is any subset
+$C$ with $\Pr(\theta \in C \mid x) = 1 - \alpha$. The most-used choice
+is the equal-tailed interval bounded by the $\alpha/2$ and
 $1 - \alpha/2$ posterior quantiles.</p>
-<p>The contrast with the frequentist confidence interval is the<br />
-conceptual hinge of the article. The credible interval makes a<br />
-direct probability statement <em>about $\theta$</em> given the realised<br />
-data: "given what I saw, there is a 95 % chance the parameter lies<br />
-in $[a, b]$". The frequentist interval makes a statement <em>about the<br />
-procedure</em>: 95 % of the intervals constructed by this rule, across<br />
-hypothetical repetitions of the experiment, would contain the true<br />
-$\theta$. After observing one specific dataset, the frequentist<br />
-interval either contains $\theta$ or it does not — there is no<br />
-probability statement about <em>that</em> interval. Both intervals can<br />
+<p>The contrast with the frequentist confidence interval is the
+conceptual hinge of the article. The credible interval makes a
+direct probability statement <em>about $\theta$</em> given the realised
+data: "given what I saw, there is a 95 % chance the parameter lies
+in $[a, b]$". The frequentist interval makes a statement <em>about the
+procedure</em>: 95 % of the intervals constructed by this rule, across
+hypothetical repetitions of the experiment, would contain the true
+$\theta$. After observing one specific dataset, the frequentist
+interval either contains $\theta$ or it does not — there is no
+probability statement about <em>that</em> interval. Both intervals can
 numerically agree in simple cases, but their interpretations differ.</p>
-<p>For a budget committee asking "will we exceed R\$ 13.2 M?" the<br />
-relevant statement is about the parameter (or the forecast), not<br />
-about the procedure. The credible interval is the operational<br />
+<p>For a budget committee asking "will we exceed R\$ 13.2 M?" the
+relevant statement is about the parameter (or the forecast), not
+about the procedure. The credible interval is the operational
 object.</p>
 <h3 id="prior-elicitation-the-budget-plan-is-a-prior">Prior elicitation: the budget plan IS a prior</h3>
-<p>The classic objection — "but the prior is subjective" — misses the<br />
-point. The budget plan was always subjective. The Bayesian framework<br />
-makes the subjectivity explicit and updateable. A planner who states<br />
-"we expect monthly cost $\mu_0$ with $\gamma$-confidence that the<br />
-truth is within $\pm w$" is implicitly specifying a Normal prior<br />
+<p>The classic objection — "but the prior is subjective" — misses the
+point. The budget plan was always subjective. The Bayesian framework
+makes the subjectivity explicit and updateable. A planner who states
+"we expect monthly cost $\mu_0$ with $\gamma$-confidence that the
+truth is within $\pm w$" is implicitly specifying a Normal prior
 $N(\mu_0, \sigma_0^2)$ with</p>
 <p>$$
 \sigma_0 = \frac{w}{z_{(1+\gamma)/2}},
 $$</p>
-<p>where $z_q$ is the standard-Normal quantile. The article's reference<br />
-scenario uses $\mu_0$ = R\$ 1,050,000,<br />
-$\sigma_0$ = R\$ 150,000 — a budget plan and a stated<br />
+<p>where $z_q$ is the standard-Normal quantile. The article's reference
+scenario uses $\mu_0$ = R\$ 1,050,000,
+$\sigma_0$ = R\$ 150,000 — a budget plan and a stated
 uncertainty, translated into a prior in one line.</p>
 <hr />
 <h2 id="conjugate-families">Conjugate Families</h2>
-<p>A family $\mathcal F$ of priors is <strong>conjugate</strong> to a sampling model<br />
-if the posterior obtained by Bayes' theorem stays in $\mathcal F$.<br />
-Hyperparameters update by an explicit rule; the marginal likelihood<br />
-is implied; sequential updating becomes addition, as the<br />
-<a href="#sequential-updating-and-shrinkage">next section</a> shows. The four<br />
+<p>A family $\mathcal F$ of priors is <strong>conjugate</strong> to a sampling model
+if the posterior obtained by Bayes' theorem stays in $\mathcal F$.
+Hyperparameters update by an explicit rule; the marginal likelihood
+is implied; sequential updating becomes addition, as the
+<a href="#sequential-updating-and-shrinkage">next section</a> shows. The four
 pairs in this section cover every component of the FYF cost model.</p>
 <figure><img src="../figures/bayesian-fyf/exp_b_conjugate_families.png" alt="Experiment B — four conjugate pairs side by side. Each panel: prior in steelblue, posterior in crimson after a small batch of synthetic data." loading="lazy"><figcaption>Experiment B — four conjugate pairs side by side. Each panel: prior in steelblue, posterior in crimson after a small batch of synthetic data.</figcaption></figure>
 <h3 id="normalnormal-known-variance-the-articles-anchor">Normal–Normal (known variance) — the article's anchor</h3>
-<p>Let $\theta$ be the unknown mean of a Normal sampling model with<br />
+<p>Let $\theta$ be the unknown mean of a Normal sampling model with
 <strong>known</strong> variance $\sigma^2$:</p>
 <p>$$
 x_1, \ldots, x_n \mid \theta \overset{\text{iid}}{\sim} N(\theta, \sigma^2),
 \qquad
 \theta \sim N(\mu_0, \sigma_0^2).
 $$</p>
-<p>The likelihood, viewed as a function of $\theta$ and after expanding<br />
-$\sum (x_i - \theta)^2 = \sum (x_i - \bar x)^2 + n(\bar x - \theta)^2$,<br />
-is proportional to $\exp\big(-\tfrac{n}{2\sigma^2}(\theta - \bar x)^2\big)$.<br />
-Multiplying by the prior, grouping powers of $\theta$, and completing<br />
+<p>The likelihood, viewed as a function of $\theta$ and after expanding
+$\sum (x_i - \theta)^2 = \sum (x_i - \bar x)^2 + n(\bar x - \theta)^2$,
+is proportional to $\exp\big(-\tfrac{n}{2\sigma^2}(\theta - \bar x)^2\big)$.
+Multiplying by the prior, grouping powers of $\theta$, and completing
 the square yields a Normal kernel with</p>
 <p>$$
 \boxed{\quad
@@ -429,8 +429,8 @@ the square yields a Normal kernel with</p>
 \mu_n = \frac{\tau_0\mu_0 + n\tau\bar x}{\tau_n},
 \quad}
 $$</p>
-<p>where $\tau \equiv 1/\sigma^2$ and $\tau_0 \equiv 1/\sigma_0^2$ are<br />
-the <strong>precisions</strong> (inverse variances). Equivalently, in variance<br />
+<p>where $\tau \equiv 1/\sigma^2$ and $\tau_0 \equiv 1/\sigma_0^2$ are
+the <strong>precisions</strong> (inverse variances). Equivalently, in variance
 form,</p>
 <p>$$
 \mu_n = \frac{\sigma^2 \mu_0 + n \sigma_0^2 \bar x}{\sigma^2 + n \sigma_0^2},
@@ -438,20 +438,20 @@ form,</p>
 \sigma_n^2 = \frac{\sigma^2 \sigma_0^2}{\sigma^2 + n \sigma_0^2}.
 $$</p>
 <p>This identity admits three equivalent readings.</p>
-<p><strong>Precision additivity.</strong> $\tau_n = \tau_0 + n\tau$. Each new<br />
-observation adds exactly $\tau$ units of precision, regardless of<br />
+<p><strong>Precision additivity.</strong> $\tau_n = \tau_0 + n\tau$. Each new
+observation adds exactly $\tau$ units of precision, regardless of
 its value.</p>
-<p><strong>Weighted average of means.</strong> With $w_0 \equiv \tau_0 / (\tau_0 + n\tau)$<br />
-and $w_d \equiv 1 - w_0$, $\mu_n = w_0\mu_0 + w_d \bar x$. The<br />
-weights are proportional to the <em>information content</em> of each<br />
+<p><strong>Weighted average of means.</strong> With $w_0 \equiv \tau_0 / (\tau_0 + n\tau)$
+and $w_d \equiv 1 - w_0$, $\mu_n = w_0\mu_0 + w_d \bar x$. The
+weights are proportional to the <em>information content</em> of each
 source — prior information $\tau_0$, data information $n\tau$.</p>
-<p><strong>Shrinkage to the prior.</strong> Equivalently, $\mu_n = \bar x + w_0(\mu_0 - \bar x)$:<br />
+<p><strong>Shrinkage to the prior.</strong> Equivalently, $\mu_n = \bar x + w_0(\mu_0 - \bar x)$:
 the data mean is shrunk toward the prior mean by a factor $w_0$.</p>
 <h3 id="normalinverse-gamma-unknown-variance">Normal–Inverse-Gamma (unknown variance)</h3>
-<p>When $\sigma^2$ is also unknown, the conjugate prior is the<br />
-<strong>Normal–Inverse-Gamma</strong>:<br />
-$\sigma^2 \sim \text{Inverse-Gamma}(\alpha_0, \beta_0)$,<br />
-$\theta \mid \sigma^2 \sim N(\mu_0, \sigma^2/\kappa_0)$. The same<br />
+<p>When $\sigma^2$ is also unknown, the conjugate prior is the
+<strong>Normal–Inverse-Gamma</strong>:
+$\sigma^2 \sim \text{Inverse-Gamma}(\alpha_0, \beta_0)$,
+$\theta \mid \sigma^2 \sim N(\mu_0, \sigma^2/\kappa_0)$. The same
 "completing the square" argument gives the four updates</p>
 <p>$$
 \mu_n = \frac{\kappa_0 \mu_0 + n\bar x}{\kappa_0 + n},
@@ -464,58 +464,58 @@ $$</p>
 \beta_n = \beta_0 + \tfrac{1}{2} S + \tfrac{1}{2} \frac{\kappa_0 n}{\kappa_0 + n} (\bar x - \mu_0)^2,
 \quad S = \sum_{i=1}^n (x_i - \bar x)^2.
 $$</p>
-<p>The marginal posterior of $\theta$ is a Student-$t$ with $2\alpha_n$<br />
-degrees of freedom; the marginal of $\sigma^2$ is<br />
-Inverse-Gamma$(\alpha_n, \beta_n)$. As $n \to \infty$ the posterior<br />
+<p>The marginal posterior of $\theta$ is a Student-$t$ with $2\alpha_n$
+degrees of freedom; the marginal of $\sigma^2$ is
+Inverse-Gamma$(\alpha_n, \beta_n)$. As $n \to \infty$ the posterior
 concentrates on $(\bar x, S/n) \to (\theta_\star, \sigma_\star^2)$.</p>
 <h3 id="gammapoisson-updating-event-rates">Gamma–Poisson: updating event rates</h3>
-<p>For monthly incident counts modelled as<br />
-$x_i \mid \lambda \sim \text{Poisson}(\lambda)$ with prior<br />
-$\lambda \sim \text{Gamma}(\alpha_0, \beta_0)$ (rate<br />
+<p>For monthly incident counts modelled as
+$x_i \mid \lambda \sim \text{Poisson}(\lambda)$ with prior
+$\lambda \sim \text{Gamma}(\alpha_0, \beta_0)$ (rate
 parameterisation), the posterior is</p>
 <p>$$
 \boxed{\quad
 \lambda \mid x_{1:n} \sim \text{Gamma}\Big(\alpha_0 + \textstyle\sum_i x_i, \beta_0 + n\Big).
 \quad}
 $$</p>
-<p>The interpretation is <strong>pseudo-observations</strong>: $\alpha_0$ acts as<br />
-"prior event count", $\beta_0$ as "prior pseudo-observation period".<br />
+<p>The interpretation is <strong>pseudo-observations</strong>: $\alpha_0$ acts as
+"prior event count", $\beta_0$ as "prior pseudo-observation period".
 Real events and real periods simply add.</p>
 <h3 id="betabinomial-updating-proportions">Beta–Binomial: updating proportions</h3>
-<p>For an overtime proportion $p$ with prior $\text{Beta}(\alpha_0, \beta_0)$<br />
+<p>For an overtime proportion $p$ with prior $\text{Beta}(\alpha_0, \beta_0)$
 and observation $x \mid p \sim \text{Binomial}(n, p)$,</p>
 <p>$$
 \boxed{\quad
 p \mid x \sim \text{Beta}(\alpha_0 + x, \beta_0 + n - x).
 \quad}
 $$</p>
-<p>The pattern repeats: $\alpha_0$ are prior successes, $\beta_0$ prior<br />
+<p>The pattern repeats: $\alpha_0$ are prior successes, $\beta_0$ prior
 failures, real data adds.</p>
 <h3 id="the-pattern">The pattern</h3>
-<p>All four pairs share the same shape: the prior contributes a finite<br />
-"imaginary" sample, the data contributes a real sample, and the<br />
-totals add. This is the intuitive content of conjugacy — and the<br />
+<p>All four pairs share the same shape: the prior contributes a finite
+"imaginary" sample, the data contributes a real sample, and the
+totals add. This is the intuitive content of conjugacy — and the
 algebraic foundation for everything that follows.</p>
 <hr />
 <h2 id="sequential-updating-and-shrinkage">Sequential Updating and Shrinkage</h2>
 <h3 id="sequential-batch">Sequential = batch</h3>
-<p>The FYF cycle feeds data <strong>one month at a time</strong>. Does the result<br />
-agree with what the analyst would obtain by waiting until December<br />
+<p>The FYF cycle feeds data <strong>one month at a time</strong>. Does the result
+agree with what the analyst would obtain by waiting until December
 and computing one batch posterior?</p>
-<p><strong>Theorem (sequential = batch).</strong> Under conditional independence,<br />
-applying the conjugate update once per observation (using the<br />
-previous posterior as the next prior) produces the <strong>same</strong><br />
+<p><strong>Theorem (sequential = batch).</strong> Under conditional independence,
+applying the conjugate update once per observation (using the
+previous posterior as the next prior) produces the <strong>same</strong>
 hyperparameters as applying the batch update directly to all data.</p>
-<p>For Normal–Normal the proof is direct: $\tau_n = \tau_0 + n\tau$ is<br />
-linear in $n$ and accumulates the same $\tau$ regardless of the<br />
-order of operations; the mean update $\mu_n = (\tau_0\mu_0 + n\tau\bar x)/\tau_n$<br />
-is the same telescoping sum either way. For general exponential<br />
-families the conjugate hyperparameter map is <em>additive</em> in $n$ and<br />
-in the sufficient statistic $\sum_i T(x_i)$, so the cumulative<br />
+<p>For Normal–Normal the proof is direct: $\tau_n = \tau_0 + n\tau$ is
+linear in $n$ and accumulates the same $\tau$ regardless of the
+order of operations; the mean update $\mu_n = (\tau_0\mu_0 + n\tau\bar x)/\tau_n$
+is the same telescoping sum either way. For general exponential
+families the conjugate hyperparameter map is <em>additive</em> in $n$ and
+in the sufficient statistic $\sum_i T(x_i)$, so the cumulative
 increments after $n$ sequential steps equal the batch increments.</p>
-<p>The theorem says the FYF cycle is <strong>not</strong> a heuristic. An analyst<br />
-who saves the previous posterior and applies the conjugate rule<br />
-month by month will, by year-end, hold exactly the posterior they<br />
+<p>The theorem says the FYF cycle is <strong>not</strong> a heuristic. An analyst
+who saves the previous posterior and applies the conjugate rule
+month by month will, by year-end, hold exactly the posterior they
 would have obtained had they waited and done one big update.</p>
 <h3 id="the-shrinkage-formula-and-three-consequences">The shrinkage formula and three consequences</h3>
 <p>The Normal–Normal posterior mean is the convex combination</p>
@@ -526,12 +526,12 @@ w_0(n) = \frac{\tau_0}{\tau_0 + n\tau} = \frac{\sigma^2/\sigma_0^2}{\sigma^2/\si
 $$</p>
 <p>Three consequences follow immediately:</p>
 <ul>
-<li><strong>Shrinkage weight decays as $1/n$</strong>. $w_0(n) = \Theta(1/n)$, with<br />
+<li><strong>Shrinkage weight decays as $1/n$</strong>. $w_0(n) = \Theta(1/n)$, with
  leading constant $\sigma^2/\sigma_0^2$.</li>
-<li><strong>Posterior variance decays as $1/n$</strong>. $\sigma_n^2 = 1/(\tau_0 + n\tau) \sim \sigma^2/n$,<br />
- matching the frequentist sampling variance of $\bar X_n$<br />
+<li><strong>Posterior variance decays as $1/n$</strong>. $\sigma_n^2 = 1/(\tau_0 + n\tau) \sim \sigma^2/n$,
+ matching the frequentist sampling variance of $\bar X_n$
  asymptotically.</li>
-<li><strong>Posterior mean converges to the data mean</strong>.<br />
+<li><strong>Posterior mean converges to the data mean</strong>.
  $\mu_n - \bar x_n = w_0(n)(\mu_0 - \bar x_n) \to 0$.</li>
 </ul>
 <p>The recursive <strong>Kalman-gain</strong> form</p>
@@ -540,13 +540,13 @@ $$</p>
 \qquad
 K_n = \frac{\sigma_{n-1}^2}{\sigma_{n-1}^2 + \sigma^2}
 $$</p>
-<p>makes the update look like signal processing: the "innovation"<br />
-$x_n - \mu_{n-1}$ is the surprise, and $K_n$ scales how much of it<br />
-the posterior absorbs. This is the discrete Kalman filter for a<br />
+<p>makes the update look like signal processing: the "innovation"
+$x_n - \mu_{n-1}$ is the surprise, and $K_n$ scales how much of it
+the posterior absorbs. This is the discrete Kalman filter for a
 static parameter.</p>
 <figure><img src="../figures/bayesian-fyf/exp_c_sequential_shrinkage.png" alt="Experiment C — sequential shrinkage. Left: posterior trajectory and 95 % credible band over 12 months. Right: the closed-form prior weight $w_0(n)$ decaying toward zero, with markers at the 80 % and 95 % data-weight thresholds." loading="lazy"><figcaption>Experiment C — sequential shrinkage. Left: posterior trajectory and 95 % credible band over 12 months. Right: the closed-form prior weight $w_0(n)$ decaying toward zero, with markers at the 80 % and 95 % data-weight thresholds.</figcaption></figure>
 <h3 id="when-does-the-data-dominate">When does the data dominate?</h3>
-<p>With reference parameters $\sigma_0 = 150{,}000$, $\sigma = 80{,}000$,<br />
+<p>With reference parameters $\sigma_0 = 150{,}000$, $\sigma = 80{,}000$,
 the ratio $\sigma^2/\sigma_0^2 \approx 0.2844$:</p>
 <table>
 <thead>
@@ -579,36 +579,36 @@ the ratio $\sigma^2/\sigma_0^2 \approx 0.2844$:</p>
 </tr>
 </tbody>
 </table>
-<p>The data's share crosses <strong>80 % at $n = 2$</strong> (already by February<br />
-with monthly revisions), <strong>95 % at $n = 6$</strong> (mid-year FYF). By the<br />
-year-end posterior, the budget plan accounts for ≈ 2.3 % of the<br />
+<p>The data's share crosses <strong>80 % at $n = 2$</strong> (already by February
+with monthly revisions), <strong>95 % at $n = 6$</strong> (mid-year FYF). By the
+year-end posterior, the budget plan accounts for ≈ 2.3 % of the
 answer.</p>
 <h3 id="prior-sensitivity">Prior sensitivity</h3>
-<p>Two analysts with the same $\sigma_0$ but different prior means<br />
-$\mu_0^{(A)} \ne \mu_0^{(B)}$ produce posteriors whose disagreement<br />
+<p>Two analysts with the same $\sigma_0$ but different prior means
+$\mu_0^{(A)} \ne \mu_0^{(B)}$ produce posteriors whose disagreement
 shrinks at exactly $w_0(n)$:</p>
 <p>$$
 \big|\mu_n^{(A)} - \mu_n^{(B)}\big| = w_0(n) \cdot \big|\mu_0^{(A)} - \mu_0^{(B)}\big|.
 $$</p>
-<p>By month 6, an initial gap of R\$ 150{,}000 has shrunk to ≈ R\$ 6{,}780.<br />
+<p>By month 6, an initial gap of R\$ 150{,}000 has shrunk to ≈ R\$ 6{,}780.
 By year-end, to ≈ R\$ 3{,}460. The data forces consensus.</p>
 <figure><img src="../figures/bayesian-fyf/exp_d_prior_sensitivity.png" alt="Experiment D — three priors converging under the same data. The right panel plots the gap on a log scale against the closed-form prediction $w_0(n) \cdot \Delta\mu_0$." loading="lazy"><figcaption>Experiment D — three priors converging under the same data. The right panel plots the gap on a log scale against the closed-form prediction $w_0(n) \cdot \Delta\mu_0$.</figcaption></figure>
 <h3 id="priordata-conflict">Prior–data conflict</h3>
-<p>Define the discrepancy $D_n = |\mu_0 - \bar x_n|/\sigma_0$. When<br />
-$D_n \gg 3$ — the data is "far from" the prior, in prior units —<br />
-the conjugate update still produces a number, but that number is<br />
-mechanical rather than meaningful. The model has assumed the prior<br />
-is correctly elicited and the sampling model is well specified; if<br />
+<p>Define the discrepancy $D_n = |\mu_0 - \bar x_n|/\sigma_0$. When
+$D_n \gg 3$ — the data is "far from" the prior, in prior units —
+the conjugate update still produces a number, but that number is
+mechanical rather than meaningful. The model has assumed the prior
+is correctly elicited and the sampling model is well specified; if
 either fails the posterior interpolates between two wrong sources.</p>
-<p>Operationally: at any FYF, if $D_n > 3$, <em>stop and diagnose</em>. Either<br />
-re-elicit the prior, or change the sampling model (often: the world<br />
-changed — re-org, vendor switch, structural shock). The Bayesian<br />
+<p>Operationally: at any FYF, if $D_n > 3$, <em>stop and diagnose</em>. Either
+re-elicit the prior, or change the sampling model (often: the world
+changed — re-org, vendor switch, structural shock). The Bayesian
 machine answers; the analyst owns the interpretation.</p>
 <hr />
 <h2 id="the-posterior-predictive">The Posterior Predictive</h2>
-<p>The posterior $\pi(\theta \mid x)$ is a means; the posterior<br />
-<strong>predictive</strong> $p(\tilde x \mid x)$ is the end. The predictive is<br />
-what the business wants: not "what is the mean cost?" but "what<br />
+<p>The posterior $\pi(\theta \mid x)$ is a means; the posterior
+<strong>predictive</strong> $p(\tilde x \mid x)$ is the end. The predictive is
+what the business wants: not "what is the mean cost?" but "what
 will next month cost? what will the year-end total cost?".</p>
 <h3 id="definition-and-decomposition">Definition and decomposition</h3>
 <p>$$
@@ -624,101 +624,101 @@ $$</p>
  + 
 \underbrace{\mathrm{Var}\big(\mathbb E[\tilde x \mid \theta] \mid x\big)}_{\text{parameter uncertainty}}.
 $$</p>
-<p>The first term is <strong>irreducible noise</strong>. The second term shrinks<br />
-with more data. A predictive interval is therefore always <strong>wider</strong><br />
-than the credible interval for $\theta$, and the gap closes<br />
-asymptotically toward $\pm 1.96\sigma$ — never toward zero. This is<br />
-the formal reason credible intervals on the parameter alone<br />
+<p>The first term is <strong>irreducible noise</strong>. The second term shrinks
+with more data. A predictive interval is therefore always <strong>wider</strong>
+than the credible interval for $\theta$, and the gap closes
+asymptotically toward $\pm 1.96\sigma$ — never toward zero. This is
+the formal reason credible intervals on the parameter alone
 under-state the uncertainty about future observations.</p>
 <figure><img src="../figures/bayesian-fyf/exp_a_prior_to_posterior.png" alt="Experiment A — single Normal-Normal update with the precision-weighted-mean decomposition. The credible interval for $\theta$ (steelblue band) is narrower than the predictive interval for the next observation (crimson band)." loading="lazy"><figcaption>Experiment A — single Normal-Normal update with the precision-weighted-mean decomposition. The credible interval for $\theta$ (steelblue band) is narrower than the predictive interval for the next observation (crimson band).</figcaption></figure>
 <h3 id="closed-forms">Closed forms</h3>
 <p>For the three pairs the article uses operationally:</p>
 <ul>
 <li><strong>Normal–Normal</strong>: $\tilde x \mid x \sim N(\mu_n, \sigma_n^2 + \sigma^2)$.</li>
-<li><strong>Gamma–Poisson</strong>: $\tilde x \mid x \sim \text{NegBin}(\alpha_n, \beta_n/(\beta_n+1))$,<br />
- shape–success parameterisation. Predictive mean $\alpha_n/\beta_n$,<br />
- variance $\alpha_n(\beta_n+1)/\beta_n^2 > \alpha_n/\beta_n$ —<br />
-<strong>overdispersion</strong> induced by parameter uncertainty.</li>
-<li><strong>Beta–Binomial</strong>: future batch of size $m$ has predictive PMF<br />
+<li><strong>Gamma–Poisson</strong>: $\tilde x \mid x \sim \text{NegBin}(\alpha_n, \beta_n/(\beta_n+1))$,
+ shape–success parameterisation. Predictive mean $\alpha_n/\beta_n$,
+ variance $\alpha_n(\beta_n+1)/\beta_n^2 > \alpha_n/\beta_n$ —
+ <strong>overdispersion</strong> induced by parameter uncertainty.</li>
+<li><strong>Beta–Binomial</strong>: future batch of size $m$ has predictive PMF
  $\Pr(\tilde x = k) = \binom{m}{k} B(\alpha_n + k, \beta_n + m - k)/B(\alpha_n, \beta_n)$.</li>
 </ul>
 <h3 id="the-year-end-total-beware-of-independence">The year-end total — beware of independence</h3>
-<p>After observing $m$ months with cumulative $S_m$, the remaining<br />
-total $\tilde S = \sum_{t=m+1}^{12} \tilde x_t$ is <strong>not</strong> the sum<br />
-of iid predictives. The future months share the unknown $\theta$<br />
+<p>After observing $m$ months with cumulative $S_m$, the remaining
+total $\tilde S = \sum_{t=m+1}^{12} \tilde x_t$ is <strong>not</strong> the sum
+of iid predictives. The future months share the unknown $\theta$
 and are therefore correlated under the posterior.</p>
-<p>Writing $\tilde x_t = \theta + \varepsilon_t$ with $\varepsilon_t$<br />
-iid $N(0, \sigma^2)$ independent of $\theta$, the sum is<br />
-$(12 - m)\theta + \sum \varepsilon_t$. The two summands are<br />
+<p>Writing $\tilde x_t = \theta + \varepsilon_t$ with $\varepsilon_t$
+iid $N(0, \sigma^2)$ independent of $\theta$, the sum is
+$(12 - m)\theta + \sum \varepsilon_t$. The two summands are
 independent given $x_{1:m}$; their variances add:</p>
 <p>$$
 \boxed{\quad
 \tilde S \mid x_{1:m} \sim N\big((12-m) \mu_m, (12-m)^2 \sigma_m^2 + (12-m) \sigma^2\big).
 \quad}
 $$</p>
-<p>The parameter-uncertainty term is <strong>quadratic</strong> in the horizon<br />
-$(12-m)$, not linear. The naïve "iid future months" formula<br />
-$(12-m)(\sigma_m^2 + \sigma^2)$ under-estimates the variance by a<br />
-factor of $(12-m)$ in the parameter share. In early months the<br />
+<p>The parameter-uncertainty term is <strong>quadratic</strong> in the horizon
+$(12-m)$, not linear. The naïve "iid future months" formula
+$(12-m)(\sigma_m^2 + \sigma^2)$ under-estimates the variance by a
+factor of $(12-m)$ in the parameter share. In early months the
 horizon is long and the naïve under-estimate is large.</p>
-<p>The annual total is $T = S_m + \tilde S$, a Normal with mean<br />
+<p>The annual total is $T = S_m + \tilde S$, a Normal with mean
 $S_m + (12-m)\mu_m$ and the variance above. Then</p>
 <p>$$
 P(T > B \mid x_{1:m})
  = 
 1 - \Phi\Big(\frac{B - (S_m + (12-m)\mu_m)}{\sqrt{(12-m)^2 \sigma_m^2 + (12-m)\sigma^2}}\Big).
 $$</p>
-<p>For the reference scenario at mid-year with<br />
-$\mu_6$ = R\$ 1,085,000,<br />
-$\sigma_6$ = R\$ 32,000,<br />
-$S_6$ = R\$ 6,510,000, $B$ = R\$ 13,200,000:<br />
-$P(T > B) \approx 26\%$ under the correct formula, vs ≈ 20 % under<br />
-the naïve iid calculation. <strong>The dependence between future months<br />
+<p>For the reference scenario at mid-year with
+$\mu_6$ = R\$ 1,085,000,
+$\sigma_6$ = R\$ 32,000,
+$S_6$ = R\$ 6,510,000, $B$ = R\$ 13,200,000:
+$P(T > B) \approx 26\%$ under the correct formula, vs ≈ 20 % under
+the naïve iid calculation. <strong>The dependence between future months
 is not a rounding error.</strong></p>
 <h3 id="monte-carlo-posterior-predictive">Monte Carlo posterior predictive</h3>
-<p>The closed forms are convenient, but the Monte Carlo recipe works<br />
+<p>The closed forms are convenient, but the Monte Carlo recipe works
 in any setting:</p>
 <ol>
 <li>Draw $\theta^{(s)} \sim \pi(\theta \mid x)$.</li>
 <li>Draw $\tilde x^{(s)} \sim f( \cdot \mid \theta^{(s)})$.</li>
 </ol>
-<p>This is exactly the simulation strategy of the companion article<br />
-<a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a>,<br />
-applied to the posterior. That article sampled from the prior; this<br />
-one samples from the posterior, which is the prior updated with<br />
-observed months. Same machine, better input. Crucially, for<br />
-multi-period sums <strong>reuse the same $\theta^{(s)}$ across all future<br />
-months in a replication</strong> — that is what preserves the correlation<br />
+<p>This is exactly the simulation strategy of the companion article
+<a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a>,
+applied to the posterior. That article sampled from the prior; this
+one samples from the posterior, which is the prior updated with
+observed months. Same machine, better input. Crucially, for
+multi-period sums <strong>reuse the same $\theta^{(s)}$ across all future
+months in a replication</strong> — that is what preserves the correlation
 that produces the quadratic variance term.</p>
 <h3 id="bayes-factors-brief">Bayes factors (brief)</h3>
-<p>For two competing models $M_1, M_2$ the <strong>Bayes factor</strong> is<br />
-$BF_{12} = p(x \mid M_1)/p(x \mid M_2)$, the ratio of marginal<br />
-likelihoods. Combined with prior model probabilities it yields<br />
-posterior model odds. Under Jeffreys' scale,<br />
-$\log_{10} BF \in [1, 1.5]$ is "strong", $> 2$ is "decisive". In<br />
-large samples $\log BF \approx -\tfrac{1}{2}(\Delta\text{BIC})$,<br />
-linking the Bayes factor to BIC and (approximately) AIC. We use the<br />
-Bayes factor as a conceptually cleaner comparator to the AIC/BIC<br />
-machinery of the companion article<br />
-<a href="probabilistic-cost-modelling.html">The Shape of What You'll Spend</a>;<br />
+<p>For two competing models $M_1, M_2$ the <strong>Bayes factor</strong> is
+$BF_{12} = p(x \mid M_1)/p(x \mid M_2)$, the ratio of marginal
+likelihoods. Combined with prior model probabilities it yields
+posterior model odds. Under Jeffreys' scale,
+$\log_{10} BF \in [1, 1.5]$ is "strong", $> 2$ is "decisive". In
+large samples $\log BF \approx -\tfrac{1}{2}(\Delta\text{BIC})$,
+linking the Bayes factor to BIC and (approximately) AIC. We use the
+Bayes factor as a conceptually cleaner comparator to the AIC/BIC
+machinery of the companion article
+<a href="probabilistic-cost-modelling.html">The Shape of What You'll Spend</a>;
 we do not use it as the article's primary inference tool.</p>
 <hr />
 <h2 id="the-fyf-model">The FYF Model</h2>
 <h3 id="the-cost-decomposition">The cost decomposition</h3>
-<p>Monthly cost decomposes into three components — salary plus<br />
+<p>Monthly cost decomposes into three components — salary plus
 benefits, overtime, and incidents:</p>
 <p>$$
 X_t = \underbrace{n_t \cdot \bar S_t \cdot \beta}_{\text{salary + benefits}}
  + \underbrace{C_{\text{ot},t}}_{\text{overtime}}
  + \underbrace{C_{\text{inc},t}}_{\text{incidents}}.
 $$</p>
-<p>For the article's central inference layer, $\theta$ is the <strong>mean<br />
-monthly cost</strong> with $X_t \mid \theta \sim N(\theta, \sigma^2)$ and<br />
-$\sigma$ known. The Gamma–Poisson incident-count and Beta–Binomial<br />
-overtime-proportion priors developed in<br />
-<a href="#conjugate-families">Conjugate Families</a> cover the other two<br />
-components and slot into the same machine; we keep the canonical<br />
-scenarios in this section single-component to isolate the Bayesian<br />
+<p>For the article's central inference layer, $\theta$ is the <strong>mean
+monthly cost</strong> with $X_t \mid \theta \sim N(\theta, \sigma^2)$ and
+$\sigma$ known. The Gamma–Poisson incident-count and Beta–Binomial
+overtime-proportion priors developed in
+<a href="#conjugate-families">Conjugate Families</a> cover the other two
+components and slot into the same machine; we keep the canonical
+scenarios in this section single-component to isolate the Bayesian
 mechanics.</p>
 <h3 id="the-revision-calendar">The revision calendar</h3>
 <table>
@@ -777,13 +777,13 @@ mechanics.</p>
 </tr>
 </tbody>
 </table>
-<p>Each FYF is a posterior. The previous posterior becomes the next<br />
-prior. By the<br />
-<a href="#sequential-updating-and-shrinkage">sequential = batch theorem</a>, the<br />
-year-end posterior equals the single batch posterior conditioned on<br />
+<p>Each FYF is a posterior. The previous posterior becomes the next
+prior. By the
+<a href="#sequential-updating-and-shrinkage">sequential = batch theorem</a>, the
+year-end posterior equals the single batch posterior conditioned on
 all 12 actuals.</p>
 <h3 id="reference-parameters">Reference parameters</h3>
-<p>A 50-person IT team, average gross monthly salary R\$ 12{,}000,<br />
+<p>A 50-person IT team, average gross monthly salary R\$ 12{,}000,
 benefit-and-charge multiplier 1.75:</p>
 <table>
 <thead>
@@ -827,46 +827,46 @@ benefit-and-charge multiplier 1.75:</p>
 </tbody>
 </table>
 <h3 id="the-fyf-model-object">The FYF model object</h3>
-<p>Operationally we package the engine as a stateful object that, for<br />
-each incoming month, (i) computes the surprise z-score before<br />
-consuming the actual, (ii) feeds the actual through the conjugate<br />
-updater, (iii) refreshes the year-end forecast and $P(T > B)$. At<br />
-the close of each quarter the same object emits a <code>QuarterlyReview</code><br />
-record with the posterior, the year-end forecast, the maximum<br />
-absolute surprise in the quarter, and a one-line recommendation<br />
-("hold", "re-elicit", "investigate shock", "request budget<br />
+<p>Operationally we package the engine as a stateful object that, for
+each incoming month, (i) computes the surprise z-score before
+consuming the actual, (ii) feeds the actual through the conjugate
+updater, (iii) refreshes the year-end forecast and $P(T > B)$. At
+the close of each quarter the same object emits a <code>QuarterlyReview</code>
+record with the posterior, the year-end forecast, the maximum
+absolute surprise in the quarter, and a one-line recommendation
+("hold", "re-elicit", "investigate shock", "request budget
 revision").</p>
 <h3 id="the-annual-cycle-end-to-end">The annual cycle, end to end</h3>
-<p>The figure below shows a full simulation of the <strong>on-target<br />
-scenario</strong>: 12 monthly actuals drawn from<br />
-$N(\theta_\star = 1{,}080{,}000, \sigma)$ (so the true mean is<br />
-slightly above the planner's expectation). The top panel walks the<br />
-posterior: a steep correction in Q1, then month-by-month tightening.<br />
-The bottom panel walks the year-end forecast: the predictive interval<br />
-narrows from $\pm \approx$ R\$ 950,000 at month 1 to<br />
+<p>The figure below shows a full simulation of the <strong>on-target
+scenario</strong>: 12 monthly actuals drawn from
+$N(\theta_\star = 1{,}080{,}000, \sigma)$ (so the true mean is
+slightly above the planner's expectation). The top panel walks the
+posterior: a steep correction in Q1, then month-by-month tightening.
+The bottom panel walks the year-end forecast: the predictive interval
+narrows from $\pm \approx$ R\$ 950,000 at month 1 to
 $\pm \approx$ R\$ 50,000 at month 11.</p>
 <figure><img src="../figures/bayesian-fyf/exp_e_fyf_quarterly.png" alt="Experiment E — full annual FYF cycle. Top: posterior trajectory with a 95 % credible band, monthly actuals as grey dots, and quarterly FYF review boxes. Bottom: year-end total predictive vs the budget ceiling." loading="lazy"><figcaption>Experiment E — full annual FYF cycle. Top: posterior trajectory with a 95 % credible band, monthly actuals as grey dots, and quarterly FYF review boxes. Bottom: year-end total predictive vs the budget ceiling.</figcaption></figure>
 <h3 id="key-questions-the-model-answers">Key questions the model answers</h3>
-<p>Five practical questions, each mapping cleanly onto a Bayesian<br />
+<p>Five practical questions, each mapping cleanly onto a Bayesian
 quantity:</p>
 <ol>
-<li><strong>Shrinkage</strong>: how much does each month pull the forecast away<br />
+<li><strong>Shrinkage</strong>: how much does each month pull the forecast away
  from the plan? — The trajectory $\mu_n$.</li>
-<li><strong>Precision</strong>: how tight is the 95 % credible interval at each<br />
+<li><strong>Precision</strong>: how tight is the 95 % credible interval at each
  FYF? — $\pm 1.96\sigma_n$.</li>
-<li><strong>Surprise detection</strong>: when should we override the update? —<br />
+<li><strong>Surprise detection</strong>: when should we override the update? —
  The surprise z-score of <a href="#diagnostics">Diagnostics</a>.</li>
-<li><strong>Prior sensitivity</strong>: how much does the prior choice matter<br />
+<li><strong>Prior sensitivity</strong>: how much does the prior choice matter
  after 6 months? — The shrinkage of the prior gap by $w_0(n)$.</li>
-<li><strong>Predictive accuracy</strong>: what is $P(T > B)$? — The<br />
-<a href="#the-year-end-total-beware-of-independence">year-end closed form</a>.</li>
+<li><strong>Predictive accuracy</strong>: what is $P(T > B)$? — The
+ <a href="#the-year-end-total-beware-of-independence">year-end closed form</a>.</li>
 </ol>
 <hr />
 <h2 id="experiments-and-results">Experiments and Results</h2>
-<p>We run eight experiments end-to-end and one animated companion. Each<br />
-script is in <code>scripts/</code>; each figure is at 300 DPI with a fixed<br />
-seed. The table indexes all eight; the three that carry the article's<br />
-sharpest claims then get the full <strong>Claim / Setup / Result /<br />
+<p>We run eight experiments end-to-end and one animated companion. Each
+script is in <code>scripts/</code>; each figure is at 300 DPI with a fixed
+seed. The table indexes all eight; the three that carry the article's
+sharpest claims then get the full <strong>Claim / Setup / Result /
 Connection</strong> treatment.</p>
 <table>
 <thead>
@@ -920,81 +920,81 @@ Connection</strong> treatment.</p>
 </tbody>
 </table>
 <h3 id="experiment-f-bayesian-vs-frequentist">Experiment F — Bayesian vs frequentist</h3>
-<p><strong>Claim.</strong> The frequentist coverage guarantee is about the procedure;<br />
-the credible interval is about <em>this</em> forecast — and for a budget<br />
+<p><strong>Claim.</strong> The frequentist coverage guarantee is about the procedure;
+the credible interval is about <em>this</em> forecast — and for a budget
 committee, the second is the operational statement.</p>
-<p><strong>Setup.</strong> 100 simulated samples of size $n = 30$ from<br />
-$N(\theta_\star, \sigma^2)$; the frequentist 95 % CI computed for<br />
+<p><strong>Setup.</strong> 100 simulated samples of size $n = 30$ from
+$N(\theta_\star, \sigma^2)$; the frequentist 95 % CI computed for
 each; one sample additionally analysed with the Bayesian machinery.</p>
-<p><strong>Result.</strong> Empirical coverage sits within Monte Carlo error of the<br />
-nominal 95 % — approximately five intervals miss the truth, the<br />
-procedure-level guarantee. The credible interval on the highlighted<br />
-sample nearly coincides numerically with the frequentist interval<br />
-(formally: the improper-prior Bayesian recovers the frequentist<br />
-sampling distribution), but the <em>statements</em> differ: probability<br />
-about $\theta$ given this dataset vs frequency across hypothetical<br />
+<p><strong>Result.</strong> Empirical coverage sits within Monte Carlo error of the
+nominal 95 % — approximately five intervals miss the truth, the
+procedure-level guarantee. The credible interval on the highlighted
+sample nearly coincides numerically with the frequentist interval
+(formally: the improper-prior Bayesian recovers the frequentist
+sampling distribution), but the <em>statements</em> differ: probability
+about $\theta$ given this dataset vs frequency across hypothetical
 repetitions.</p>
-<p><strong>Connection.</strong> The credible-vs-confidence distinction drawn in<br />
-<a href="#bayes-theorem-for-budget-analysts">Bayes' Theorem for Budget Analysts</a>,<br />
+<p><strong>Connection.</strong> The credible-vs-confidence distinction drawn in
+<a href="#bayes-theorem-for-budget-analysts">Bayes' Theorem for Budget Analysts</a>,
 made visual.</p>
 <figure><img src="../figures/bayesian-fyf/exp_f_bayesian_vs_frequentist.png" alt="Experiment F — frequentist coverage simulation (top) vs a single Bayesian credible interval (bottom)." loading="lazy"><figcaption>Experiment F — frequentist coverage simulation (top) vs a single Bayesian credible interval (bottom).</figcaption></figure>
 <h3 id="experiment-g-bayes-factors-and-aic">Experiment G — Bayes factors and AIC</h3>
-<p><strong>Claim.</strong> With even a few months of data, the Bayes factor<br />
+<p><strong>Claim.</strong> With even a few months of data, the Bayes factor
 decisively separates a well-centred prior from a badly-centred one.</p>
-<p><strong>Setup.</strong> Data simulated from a prior centred at the truth; compared<br />
-against an alternative prior 5 prior standard deviations off. Log<br />
-marginal likelihoods computed in closed form; AIC computed under the<br />
+<p><strong>Setup.</strong> Data simulated from a prior centred at the truth; compared
+against an alternative prior 5 prior standard deviations off. Log
+marginal likelihoods computed in closed form; AIC computed under the
 same identification.</p>
-<p><strong>Result.</strong> The Bayes factor in favour of the right prior crosses the<br />
-"decisive" threshold on Jeffreys' scale by about $n = 6$ and grows<br />
+<p><strong>Result.</strong> The Bayes factor in favour of the right prior crosses the
+"decisive" threshold on Jeffreys' scale by about $n = 6$ and grows
 exponentially thereafter. AIC agrees on direction.</p>
-<p><strong>Connection.</strong> The <a href="#bayes-factors-brief">Bayes-factor comparator</a><br />
-in action, and the bridge to the model-selection machinery of<br />
+<p><strong>Connection.</strong> The <a href="#bayes-factors-brief">Bayes-factor comparator</a>
+in action, and the bridge to the model-selection machinery of
 <a href="probabilistic-cost-modelling.html">The Shape of What You'll Spend</a>.</p>
 <figure><img src="../figures/bayesian-fyf/exp_g_model_comparison.png" alt="Experiment G — log marginal likelihoods, Bayes factor trajectory, and Jeffreys-scale interpretation." loading="lazy"><figcaption>Experiment G — log marginal likelihoods, Bayes factor trajectory, and Jeffreys-scale interpretation.</figcaption></figure>
 <h3 id="experiment-h-posterior-predictive-check">Experiment H — Posterior predictive check</h3>
-<p><strong>Claim.</strong> Under correct specification, the model's own predictions<br />
+<p><strong>Claim.</strong> Under correct specification, the model's own predictions
 are calibrated — and the calibration triple is a usable self-test.</p>
-<p><strong>Setup.</strong> 250 simulated annual cycles: for each, a true $\theta$<br />
-drawn from the prior, 12 actuals drawn from $N(\theta, \sigma^2)$,<br />
+<p><strong>Setup.</strong> 250 simulated annual cycles: for each, a true $\theta$
+drawn from the prior, 12 actuals drawn from $N(\theta, \sigma^2)$,
 the model fed those actuals and its predictive intervals recorded.</p>
-<p><strong>Result.</strong> Aggregated across replications: (i) the calibration plot<br />
-lies on the diagonal (empirical coverage matches nominal), (ii) the<br />
-histogram of surprise z-scores is approximately $N(0, 1)$, (iii) the<br />
-CDF of two-sided predictive p-values is approximately Uniform.<br />
+<p><strong>Result.</strong> Aggregated across replications: (i) the calibration plot
+lies on the diagonal (empirical coverage matches nominal), (ii) the
+histogram of surprise z-scores is approximately $N(0, 1)$, (iii) the
+CDF of two-sided predictive p-values is approximately Uniform.
 Deviations indicate mis-specification, not random Monte Carlo wiggle.</p>
-<p><strong>Connection.</strong> Validates every check used operationally in<br />
+<p><strong>Connection.</strong> Validates every check used operationally in
 <a href="#diagnostics">Diagnostics</a>.</p>
 <figure><img src="../figures/bayesian-fyf/exp_h_posterior_predictive_check.png" alt="Experiment H — calibration plot (left), z-score histogram (centre), p-value CDF (right). Aggregated over 250 simulated cycles." loading="lazy"><figcaption>Experiment H — calibration plot (left), z-score histogram (centre), p-value CDF (right). Aggregated over 250 simulated cycles.</figcaption></figure>
 <hr />
 <h2 id="diagnostics">Diagnostics</h2>
-<p>A Bayesian model is only as good as its assumptions. The diagnostic<br />
-layer answers a single question: when should we stop trusting the<br />
+<p>A Bayesian model is only as good as its assumptions. The diagnostic
+layer answers a single question: when should we stop trusting the
 output?</p>
 <h3 id="the-surprise-z-score">The surprise z-score</h3>
 <p>The standardised innovation under the posterior predictive is</p>
 <p>$$
 z_t = \frac{x_t - \mu_{t-1}}{\sqrt{\sigma_{t-1}^2 + \sigma^2}}.
 $$</p>
-<p>Under correct specification $z_t \mid x_{1:t-1} \sim N(0, 1)$. The<br />
-heuristic thresholds: $|z_t| > 2$ is "uncomfortable", $|z_t| > 3$<br />
-is "investigate". The $z$ scores are not iid in finite samples —<br />
-the previous posterior is itself random — but they are exchangeable<br />
+<p>Under correct specification $z_t \mid x_{1:t-1} \sim N(0, 1)$. The
+heuristic thresholds: $|z_t| > 2$ is "uncomfortable", $|z_t| > 3$
+is "investigate". The $z$ scores are not iid in finite samples —
+the previous posterior is itself random — but they are exchangeable
 under correct specification, which is enough for routine practice.</p>
 <h3 id="calibration">Calibration</h3>
-<p>A 95 % equal-tailed predictive interval should contain the next<br />
-actual approximately 95 % of the time. Aggregating across $T$<br />
-months and $K$ years, the <strong>calibration score</strong> is the fraction of<br />
-actuals inside the interval. A binomial test checks whether the<br />
+<p>A 95 % equal-tailed predictive interval should contain the next
+actual approximately 95 % of the time. Aggregating across $T$
+months and $K$ years, the <strong>calibration score</strong> is the fraction of
+actuals inside the interval. A binomial test checks whether the
 score deviates significantly from the nominal level.</p>
-<p>Under-coverage at the steady-state, large-$n$ regime indicates the<br />
-sampling-noise term $\sigma$ is too small. Over-coverage indicates<br />
-$\sigma$ is too large. Persistent miscalibration that <em>changes with<br />
+<p>Under-coverage at the steady-state, large-$n$ regime indicates the
+sampling-noise term $\sigma$ is too small. Over-coverage indicates
+$\sigma$ is too large. Persistent miscalibration that <em>changes with
 $n$</em> points instead at the prior — too tight or too loose.</p>
 <h3 id="cumulative-surprise">Cumulative surprise</h3>
-<p>$S_n = \sum_{t \le n} z_t$ is, under correct specification, a<br />
-random walk with mean zero and variance growing linearly in $n$.<br />
-A sustained drift of $S_n / \sqrt n$ outside $[-2, 2]$ flags<br />
+<p>$S_n = \sum_{t \le n} z_t$ is, under correct specification, a
+random walk with mean zero and variance growing linearly in $n$.
+A sustained drift of $S_n / \sqrt n$ outside $[-2, 2]$ flags
 <strong>structural drift</strong> — the sampling model has gone stale.</p>
 <h3 id="when-the-diagnostic-fires">When the diagnostic fires</h3>
 <p>The article's operational rule:</p>
@@ -1024,128 +1024,128 @@ A sustained drift of $S_n / \sqrt n$ outside $[-2, 2]$ flags<br />
 </tr>
 </tbody>
 </table>
-<p>The diagnostic does not replace judgement. It tells the analyst<br />
+<p>The diagnostic does not replace judgement. It tells the analyst
 when to stop trusting the conjugate update and start asking why.</p>
 <hr />
 <h2 id="connection-to-the-series">Connection to the Series</h2>
-<p>This is the fourth article in a series on probabilistic methods for<br />
-budget analytics. Each earlier article supplies a building block that<br />
+<p>This is the fourth article in a series on probabilistic methods for
+budget analytics. Each earlier article supplies a building block that
 this one uses or extends.</p>
 <ul>
-<li><strong><a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a>.</strong><br />
- Its simulation strategy reappears here as the<br />
-<a href="#monte-carlo-posterior-predictive">Monte Carlo posterior predictive</a>.<br />
- The only change is the <em>input</em> distribution: that article sampled<br />
- from the prior; this one samples from the posterior, which is the<br />
+<li><strong><a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a>.</strong>
+ Its simulation strategy reappears here as the
+ <a href="#monte-carlo-posterior-predictive">Monte Carlo posterior predictive</a>.
+ The only change is the <em>input</em> distribution: that article sampled
+ from the prior; this one samples from the posterior, which is the
  prior updated with observed months. Same machine, better input.</li>
-<li><strong><a href="probabilistic-cost-modelling.html">The Shape of What You'll Spend</a>.</strong><br />
- The four conjugate prior distributions — Normal, Inverse-Gamma,<br />
- Gamma, Beta — are exactly the families fitted there, and the<br />
- likelihood building blocks (Normal, Poisson, Binomial) come from<br />
- the same catalogue. Its MLE / AIC / BIC machinery appears here as<br />
- the comparator in <a href="#bayes-factors-brief">Bayes factors</a> and<br />
+<li><strong><a href="probabilistic-cost-modelling.html">The Shape of What You'll Spend</a>.</strong>
+ The four conjugate prior distributions — Normal, Inverse-Gamma,
+ Gamma, Beta — are exactly the families fitted there, and the
+ likelihood building blocks (Normal, Poisson, Binomial) come from
+ the same catalogue. Its MLE / AIC / BIC machinery appears here as
+ the comparator in <a href="#bayes-factors-brief">Bayes factors</a> and
  Experiment G.</li>
-<li><strong><a href="headcount-dynamics.html">The Team That Replaces Itself</a>.</strong><br />
- That article modelled the evolution of $n_t$ — team size — via a<br />
- birth-death chain. Plugged into<br />
-<a href="#the-cost-decomposition">the cost decomposition</a><br />
- $X_t = n_t \bar S_t \beta + \cdots$, it allows $n_t$ to drift over<br />
- the year: its transition rates feed the headcount portion, while<br />
+<li><strong><a href="headcount-dynamics.html">The Team That Replaces Itself</a>.</strong>
+ That article modelled the evolution of $n_t$ — team size — via a
+ birth-death chain. Plugged into
+ <a href="#the-cost-decomposition">the cost decomposition</a>
+ $X_t = n_t \bar S_t \beta + \cdots$, it allows $n_t$ to drift over
+ the year: its transition rates feed the headcount portion, while
  the Bayesian layer here infers the cost-per-head given $n_t$.</li>
 </ul>
-<p>Together the four articles cover a single problem from four sides:<br />
-how to <em>simulate</em> it, how to <em>fit</em> its components, how its<br />
-<em>components evolve</em>, and — this article — how to <em>learn from<br />
+<p>Together the four articles cover a single problem from four sides:
+how to <em>simulate</em> it, how to <em>fit</em> its components, how its
+<em>components evolve</em>, and — this article — how to <em>learn from
 incoming data</em>.</p>
 <hr />
 <h2 id="a-practical-framework">A Practical Framework</h2>
 <p>A short checklist, derived from the article's central results.</p>
 <ol>
-<li><strong>Translate the plan into a prior.</strong> Plan value is $\mu_0$;<br />
- stated confidence and band width fix $\sigma_0 = w/z_{(1+\gamma)/2}$.<br />
+<li><strong>Translate the plan into a prior.</strong> Plan value is $\mu_0$;
+ stated confidence and band width fix $\sigma_0 = w/z_{(1+\gamma)/2}$.
  Document both. Re-elicit at the start of each fiscal year.</li>
-<li><strong>Score every FYF on shrinkage and precision.</strong> Report<br />
- $\mu_n$, $\sigma_n$, the 95 % credible interval, and the prior<br />
- weight $w_0(n)$. The prior weight tells the audience how much<br />
- the new forecast still leans on the original plan; it should<br />
+<li><strong>Score every FYF on shrinkage and precision.</strong> Report
+ $\mu_n$, $\sigma_n$, the 95 % credible interval, and the prior
+ weight $w_0(n)$. The prior weight tells the audience how much
+ the new forecast still leans on the original plan; it should
  trend toward zero.</li>
-<li><strong>Report the predictive, not the posterior, for forward-looking<br />
- questions.</strong> Internal "what is our best estimate of the mean?"<br />
- uses the credible interval. External "will we exceed the<br />
- budget?" uses the predictive: $P(T > B)$ via the<br />
-<a href="#the-year-end-total-beware-of-independence">year-end formula</a>,<br />
+<li><strong>Report the predictive, not the posterior, for forward-looking
+ questions.</strong> Internal "what is our best estimate of the mean?"
+ uses the credible interval. External "will we exceed the
+ budget?" uses the predictive: $P(T > B)$ via the
+ <a href="#the-year-end-total-beware-of-independence">year-end formula</a>,
  with the <strong>correct</strong> quadratic-horizon variance.</li>
-<li><strong>Run the diagnostic at every quarterly review.</strong> Compute the<br />
- surprise z-scores for the months of the quarter, the calibration<br />
- score on the year-to-date, and the cumulative surprise.<br />
- Investigate any single $|z| > 3$, any pattern of $|z| > 2$, or<br />
+<li><strong>Run the diagnostic at every quarterly review.</strong> Compute the
+ surprise z-scores for the months of the quarter, the calibration
+ score on the year-to-date, and the cumulative surprise.
+ Investigate any single $|z| > 3$, any pattern of $|z| > 2$, or
  persistent miscalibration.</li>
-<li><strong>Treat prior–data conflict as a signal, not a number.</strong> When<br />
- $D_n = |\mu_0 - \bar x_n|/\sigma_0 > 3$, stop and ask why. The<br />
- model assumed both the prior and the sampling model were well<br />
- specified; if either fails, the posterior interpolates between<br />
- two wrong sources. The right action is rarely to trust the<br />
- posterior — usually it is to step outside the model and<br />
+<li><strong>Treat prior–data conflict as a signal, not a number.</strong> When
+ $D_n = |\mu_0 - \bar x_n|/\sigma_0 > 3$, stop and ask why. The
+ model assumed both the prior and the sampling model were well
+ specified; if either fails, the posterior interpolates between
+ two wrong sources. The right action is rarely to trust the
+ posterior — usually it is to step outside the model and
  diagnose.</li>
 </ol>
-<p>The framework is short by design. Bayesian inference does the math;<br />
+<p>The framework is short by design. Bayesian inference does the math;
 the analyst does the judgement.</p>
 <hr />
 <h2 id="limitations">Limitations</h2>
 <p>The closed forms are the article's selling point — and its boundary.</p>
-<p><strong>Known observation noise.</strong> The central Normal–Normal layer treats<br />
-$\sigma$ as known. In practice it is estimated from history, and<br />
-underestimating it makes every posterior overconfident. The<br />
-Normal–Inverse-Gamma extension handles unknown variance at the cost<br />
-of Student-$t$ predictives; the diagnostics exist precisely to catch<br />
+<p><strong>Known observation noise.</strong> The central Normal–Normal layer treats
+$\sigma$ as known. In practice it is estimated from history, and
+underestimating it makes every posterior overconfident. The
+Normal–Inverse-Gamma extension handles unknown variance at the cost
+of Student-$t$ predictives; the diagnostics exist precisely to catch
 a mis-set $\sigma$.</p>
-<p><strong>Exchangeable months.</strong> The sampling model treats monthly actuals as<br />
-iid draws around $\theta$. Seasonality, one-off events booked to a<br />
-single month, and within-year trends violate this; the cumulative<br />
-surprise statistic detects the drift but the model itself cannot<br />
+<p><strong>Exchangeable months.</strong> The sampling model treats monthly actuals as
+iid draws around $\theta$. Seasonality, one-off events booked to a
+single month, and within-year trends violate this; the cumulative
+surprise statistic detects the drift but the model itself cannot
 represent it.</p>
-<p><strong>Correct specification is assumed, not tested by the update.</strong> The<br />
-conjugate machine always returns a number. Under prior–data conflict<br />
-($D_n > 3$) that number interpolates between two wrong sources — the<br />
+<p><strong>Correct specification is assumed, not tested by the update.</strong> The
+conjugate machine always returns a number. Under prior–data conflict
+($D_n > 3$) that number interpolates between two wrong sources — the
 framework's own advice is to stop and step outside the model.</p>
-<p><strong>Conjugate-only scope.</strong> No MCMC, no hierarchical pooling across<br />
-cost centres, no nonparametrics. The single-team, single-parameter<br />
-scenarios isolate the mechanics; a portfolio of teams sharing<br />
-information requires the hierarchical extension deferred to future<br />
+<p><strong>Conjugate-only scope.</strong> No MCMC, no hierarchical pooling across
+cost centres, no nonparametrics. The single-team, single-parameter
+scenarios isolate the mechanics; a portfolio of teams sharing
+information requires the hierarchical extension deferred to future
 work.</p>
-<p><strong>Synthetic data.</strong> All experiments use simulated actuals with known<br />
-ground truth — the right tool for validating the machinery, but real<br />
-FYF data brings reporting lags, accrual adjustments, and re-orgs<br />
+<p><strong>Synthetic data.</strong> All experiments use simulated actuals with known
+ground truth — the right tool for validating the machinery, but real
+FYF data brings reporting lags, accrual adjustments, and re-orgs
 that the clean model does not see.</p>
 <hr />
 <h2 id="conclusion">Conclusion</h2>
-<p>A budget forecast that ignores its own history is a memoryless<br />
-estimator. Bayesian updating is the corrective: it combines the<br />
-budget plan (prior) with the observed actuals (likelihood) into a<br />
-revised forecast (posterior) that is mathematically optimal under<br />
-squared-error loss, monotonically tightens with each new month of<br />
-data, and reports its own uncertainty with auditable closed-form<br />
+<p>A budget forecast that ignores its own history is a memoryless
+estimator. Bayesian updating is the corrective: it combines the
+budget plan (prior) with the observed actuals (likelihood) into a
+revised forecast (posterior) that is mathematically optimal under
+squared-error loss, monotonically tightens with each new month of
+data, and reports its own uncertainty with auditable closed-form
 intervals.</p>
 <p>Three operational gains follow:</p>
 <ul>
-<li>The <strong>precision-weighted mean</strong> replaces ad-hoc reweighting of<br />
- plan vs actuals. The weights are functions of stated<br />
+<li>The <strong>precision-weighted mean</strong> replaces ad-hoc reweighting of
+ plan vs actuals. The weights are functions of stated
  uncertainties, not gut feeling.</li>
-<li><strong>Monotonic shrinkage</strong> replaces vague claims that "the forecast<br />
- got tighter": $\sigma_n$ decays at exactly $1/\sqrt n$, with a<br />
+<li><strong>Monotonic shrinkage</strong> replaces vague claims that "the forecast
+ got tighter": $\sigma_n$ decays at exactly $1/\sqrt n$, with a
  closed form for the data-share threshold.</li>
-<li>The <strong>posterior predictive</strong> answers $P(\text{annual total} > B)$<br />
- directly, accounting for both parameter uncertainty and future<br />
- noise — and including the often-missed dependence between<br />
+<li>The <strong>posterior predictive</strong> answers $P(\text{annual total} > B)$
+ directly, accounting for both parameter uncertainty and future
+ noise — and including the often-missed dependence between
  unobserved months that share $\theta$.</li>
 </ul>
-<p>The natural next article extends this framework to <strong>hierarchical<br />
-models</strong>: pooling information across cost centres, business units,<br />
-or teams. The conjugate machinery generalises directly; the<br />
-hierarchical step couples multiple FYF cycles through a shared<br />
-prior on the cross-team variation. That generalisation is for<br />
+<p>The natural next article extends this framework to <strong>hierarchical
+models</strong>: pooling information across cost centres, business units,
+or teams. The conjugate machinery generalises directly; the
+hierarchical step couples multiple FYF cycles through a shared
+prior on the cross-team variation. That generalisation is for
 another article.</p>
-<p>For now: every FYF is a Bayesian update. The framework above turns<br />
+<p>For now: every FYF is a Bayesian update. The framework above turns
 that observation into a tool.</p>
 <hr />
 <h2 id="references">References</h2>
@@ -1161,12 +1161,12 @@ that observation into a tool.</p>
 <li>West, M. &amp; Harrison, J. (1997). <em>Bayesian Forecasting and Dynamic Models</em>. Springer.</li>
 </ul>
 <hr />
-<p><em>All figures and numbers in this article are reproduced by versioned<br />
-scripts with fixed seeds in the<br />
-<a href="https://github.com/brunoramosmartins/bayesian-fyf-article">companion repository</a>.<br />
-The conjugate updaters (<code>src/conjugate.py</code>), sequential engine<br />
-(<code>src/updating.py</code>), predictive (<code>src/predictive.py</code>), FYF model<br />
-(<code>src/fyf_model.py</code>), and diagnostics (<code>src/diagnostics.py</code>) are<br />
+<p><em>All figures and numbers in this article are reproduced by versioned
+scripts with fixed seeds in the
+<a href="https://github.com/brunoramosmartins/bayesian-fyf-article">companion repository</a>.
+The conjugate updaters (<code>src/conjugate.py</code>), sequential engine
+(<code>src/updating.py</code>), predictive (<code>src/predictive.py</code>), FYF model
+(<code>src/fyf_model.py</code>), and diagnostics (<code>src/diagnostics.py</code>) are
 documented and unit-tested.</em></p>
           
         </article>

--- a/posts/headcount-dynamics.html
+++ b/posts/headcount-dynamics.html
@@ -279,109 +279,109 @@
 </blockquote>
 <hr />
 <h2 id="headcount-is-a-stochastic-process">Headcount Is a Stochastic Process</h2>
-<p>A workforce plan typically reads as a sequence of integers. <em>45 people in<br />
-January. 50 in March. 60 by year-end.</em> The numbers feel concrete, but they<br />
-are projections from a model in which people stop leaving, hires arrive on<br />
-schedule, and promotions happen on demand. None of these assumptions hold.<br />
-What planners actually face is a <em>random process</em>: at any moment, employees<br />
-can leave, get promoted, or be hired. The number of people on the team<br />
-twelve months from today is a random variable with a distribution, not a<br />
+<p>A workforce plan typically reads as a sequence of integers. <em>45 people in
+January. 50 in March. 60 by year-end.</em> The numbers feel concrete, but they
+are projections from a model in which people stop leaving, hires arrive on
+schedule, and promotions happen on demand. None of these assumptions hold.
+What planners actually face is a <em>random process</em>: at any moment, employees
+can leave, get promoted, or be hired. The number of people on the team
+twelve months from today is a random variable with a distribution, not a
 single value.</p>
-<p>The financial consequence is direct. In an IT organisation, salaries plus<br />
-the per-person costs that follow a head — software licences, cloud<br />
-provisioning quotas, devices, training budgets — are by far the dominant<br />
-share of the operating budget. When headcount is uncertain, <em>the budget is<br />
-uncertain</em>: a 10% miss in average team size translates into a 10% miss in<br />
-the line that funds salaries and a similar swing in everything that scales<br />
-with seats. Most workforce plans implicitly assume zero variance — they<br />
-state a number and proceed. What this article shows is that the variance<br />
-is not only non-zero, it is computable, and once you know its shape you<br />
+<p>The financial consequence is direct. In an IT organisation, salaries plus
+the per-person costs that follow a head — software licences, cloud
+provisioning quotas, devices, training budgets — are by far the dominant
+share of the operating budget. When headcount is uncertain, <em>the budget is
+uncertain</em>: a 10% miss in average team size translates into a 10% miss in
+the line that funds salaries and a similar swing in everything that scales
+with seats. Most workforce plans implicitly assume zero variance — they
+state a number and proceed. What this article shows is that the variance
+is not only non-zero, it is computable, and once you know its shape you
 can plan against it instead of pretending it isn't there.</p>
-<p>Once headcount is recognised as a random process, three questions become<br />
+<p>Once headcount is recognised as a random process, three questions become
 quantifiable that the deterministic plan cannot answer:</p>
 <ol>
-<li><strong>Where will the team settle?</strong> If hiring and attrition rates persist,<br />
-   the team size and composition converge to a <em>stationary distribution</em> —<br />
+<li><strong>Where will the team settle?</strong> If hiring and attrition rates persist,
+   the team size and composition converge to a <em>stationary distribution</em> —
    not necessarily where the plan said.</li>
-<li><strong>How long will it take?</strong> The expected time to reach a target headcount<br />
-   is the <em>hitting time</em> of a Markov chain, computable from the transition<br />
+<li><strong>How long will it take?</strong> The expected time to reach a target headcount
+   is the <em>hitting time</em> of a Markov chain, computable from the transition
    matrix.</li>
-<li><strong>What is the probability of hitting the plan?</strong> $P(n_{12} \geq 50)$ is a<br />
-   one-line formula once the chain is specified, and<br />
-<a href="#the-headcount-model">The Headcount Model</a> shows what moves it.</li>
+<li><strong>What is the probability of hitting the plan?</strong> $P(n_{12} \geq 50)$ is a
+   one-line formula once the chain is specified, and
+   <a href="#the-headcount-model">The Headcount Model</a> shows what moves it.</li>
 </ol>
-<p>This article speaks directly to the companion,<br />
-<a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a>.<br />
-There, the total annual budget was simulated <strong>given</strong> a fixed<br />
-headcount. Here, we model how headcount itself evolves over time, and<br />
-<a href="#the-bridge-to-the-budget">The Bridge to the Budget</a> closes the loop: the<br />
-team-size distribution produced here feeds the budget simulation of that<br />
-article. Together, the two cover the full problem of planning a personnel<br />
+<p>This article speaks directly to the companion,
+<a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a>.
+There, the total annual budget was simulated <strong>given</strong> a fixed
+headcount. Here, we model how headcount itself evolves over time, and
+<a href="#the-bridge-to-the-budget">The Bridge to the Budget</a> closes the loop: the
+team-size distribution produced here feeds the budget simulation of that
+article. Together, the two cover the full problem of planning a personnel
 budget under uncertainty.</p>
-<p>The mathematics used is mature. Markov chains in discrete time go back to<br />
-Markov's original 1906 paper. Continuous-time chains and the birth-death<br />
-specialisation, which model continuous flows of hiring and attrition, are<br />
-classical material in operations research and queuing theory. What the<br />
-present article does is <em>apply</em> this apparatus end-to-end to a concrete<br />
-workforce planning problem — without leaving any derivation implicit<br />
+<p>The mathematics used is mature. Markov chains in discrete time go back to
+Markov's original 1906 paper. Continuous-time chains and the birth-death
+specialisation, which model continuous flows of hiring and attrition, are
+classical material in operations research and queuing theory. What the
+present article does is <em>apply</em> this apparatus end-to-end to a concrete
+workforce planning problem — without leaving any derivation implicit
 along the way.</p>
-<p>The argument unfolds in three layers. <strong>First</strong>,<br />
-<a href="#markov-chains">Markov chains</a> introduce the main mathematical object,<br />
-and <a href="#where-will-the-team-settle">Where Will the Team Settle?</a> answers the<br />
-long-run question via the stationary distribution. <strong>Second</strong>,<br />
-<a href="#how-long-will-it-take">How Long Will It Take?</a> adds absorption analysis —<br />
-the fundamental matrix $N = (I - Q)^{-1}$ — which answers questions like<br />
-"how long until the team is empty under a hiring freeze?". <strong>Third</strong>,<br />
-<a href="#birth-death-processes">Birth-Death Processes</a> swap discrete months for<br />
-continuous time and give a closed-form Poisson distribution for team size.<br />
-<a href="#the-headcount-model">The Headcount Model</a> brings everything together,<br />
-runs five realistic scenarios, and the<br />
-<a href="#experiments-and-results">experiments</a> validate every theoretical claim<br />
+<p>The argument unfolds in three layers. <strong>First</strong>,
+<a href="#markov-chains">Markov chains</a> introduce the main mathematical object,
+and <a href="#where-will-the-team-settle">Where Will the Team Settle?</a> answers the
+long-run question via the stationary distribution. <strong>Second</strong>,
+<a href="#how-long-will-it-take">How Long Will It Take?</a> adds absorption analysis —
+the fundamental matrix $N = (I - Q)^{-1}$ — which answers questions like
+"how long until the team is empty under a hiring freeze?". <strong>Third</strong>,
+<a href="#birth-death-processes">Birth-Death Processes</a> swap discrete months for
+continuous time and give a closed-form Poisson distribution for team size.
+<a href="#the-headcount-model">The Headcount Model</a> brings everything together,
+runs five realistic scenarios, and the
+<a href="#experiments-and-results">experiments</a> validate every theoretical claim
 empirically.</p>
 <hr />
 <h2 id="markov-chains">Markov Chains</h2>
-<p>Before formalising, build the intuition. Imagine a single employee and<br />
-follow them month by month. In any given month they sit in one of four<br />
-states — Junior, Mid, Senior, or <em>they have already left the company</em>. By<br />
-the start of the next month they may have been promoted, may have left,<br />
-or may still be in the same state. The probabilities of these transitions<br />
-depend only on where they are <em>now</em> — not on how long they have been<br />
-there, not on the path that brought them. This property — "the past is<br />
+<p>Before formalising, build the intuition. Imagine a single employee and
+follow them month by month. In any given month they sit in one of four
+states — Junior, Mid, Senior, or <em>they have already left the company</em>. By
+the start of the next month they may have been promoted, may have left,
+or may still be in the same state. The probabilities of these transitions
+depend only on where they are <em>now</em> — not on how long they have been
+there, not on the path that brought them. This property — "the past is
 summarised by the present" — is what makes the process a <strong>Markov chain</strong>.</p>
-<p>The practical advantage is large. To describe the entire future behaviour<br />
-of the system, you need only one table of transition probabilities between<br />
-states. No long memory, no individualised history. The model is simpler<br />
-than reality (in practice, a five-year-tenure Junior probably leaves at a<br />
-different rate than a freshly-hired one), but it is faithful enough for<br />
-planning questions, and it is <em>analytically tractable</em>. The rest of this<br />
-section formalises the idea; the two sections that follow show what<br />
+<p>The practical advantage is large. To describe the entire future behaviour
+of the system, you need only one table of transition probabilities between
+states. No long memory, no individualised history. The model is simpler
+than reality (in practice, a five-year-tenure Junior probably leaves at a
+different rate than a freshly-hired one), but it is faithful enough for
+planning questions, and it is <em>analytically tractable</em>. The rest of this
+section formalises the idea; the two sections that follow show what
 tractability buys.</p>
 <h3 id="formal-definition">Formal definition</h3>
-<p>A discrete-time Markov chain on a finite state space $S = \{1, \ldots, K\}$<br />
-is a sequence of random variables $(X_n)_{n \geq 0}$ such that the<br />
-probability of the next state depends only on the present state, not on the<br />
+<p>A discrete-time Markov chain on a finite state space $S = \{1, \ldots, K\}$
+is a sequence of random variables $(X_n)_{n \geq 0}$ such that the
+probability of the next state depends only on the present state, not on the
 history:</p>
 <p>$$
 P(X_{n+1} = j \mid X_n = i, X_{n-1}, \ldots, X_0)  =  P(X_{n+1} = j \mid X_n = i)  =  p_{ij}.
 $$</p>
-<p>This is the <strong>Markov property</strong> — the past is summarised by the present.<br />
-The numbers $p_{ij}$ form the <strong>transition matrix</strong> $P = (p_{ij})$. Each row<br />
+<p>This is the <strong>Markov property</strong> — the past is summarised by the present.
+The numbers $p_{ij}$ form the <strong>transition matrix</strong> $P = (p_{ij})$. Each row
 of $P$ is a probability distribution over the next state, so</p>
 <p>$$
 \sum_{j \in S} p_{ij}  =  1 \quad \text{for every } i,
 $$</p>
 <p>and $P$ is <strong>row-stochastic</strong>: every row sums to 1.</p>
 <h3 id="notation-set-up">Notation set-up</h3>
-<p>Throughout the article, $\pi_n$ denotes the row-vector distribution of<br />
-$X_n$, so $\pi_{n+1} = \pi_n P$ and $\pi_n = \pi_0 P^n$. We use $\mathbf{1}$<br />
-for the column vector of ones; $e_i$ for the standard basis row vector with<br />
-1 in position $i$. State labels for the headcount example are<br />
-$S = \{J, M, S, E\}$ for Junior, Mid, Senior, Exit. Stationary distributions<br />
-are written $\pi$ without subscript. The eigenvalues of $P$ are<br />
-$\lambda_1, \lambda_2, \ldots$ in decreasing order of modulus; for a<br />
+<p>Throughout the article, $\pi_n$ denotes the row-vector distribution of
+$X_n$, so $\pi_{n+1} = \pi_n P$ and $\pi_n = \pi_0 P^n$. We use $\mathbf{1}$
+for the column vector of ones; $e_i$ for the standard basis row vector with
+1 in position $i$. State labels for the headcount example are
+$S = \{J, M, S, E\}$ for Junior, Mid, Senior, Exit. Stationary distributions
+are written $\pi$ without subscript. The eigenvalues of $P$ are
+$\lambda_1, \lambda_2, \ldots$ in decreasing order of modulus; for a
 row-stochastic matrix $\lambda_1 = 1$ always.</p>
 <h3 id="the-headcount-chain">The headcount chain</h3>
-<p>For an IT team with three career levels and an Exit state, a plausible<br />
+<p>For an IT team with three career levels and an Exit state, a plausible
 month-to-month transition matrix is</p>
 <p>$$
 P = \begin{pmatrix}
@@ -391,244 +391,244 @@ P = \begin{pmatrix}
 0.50 & 0    & 0    & 0.50
 \end{pmatrix}.
 $$</p>
-<p>The first three rows encode promotion and attrition rates per career level.<br />
-The last row models <em>replacement hiring</em>: an Exit slot returns to Junior<br />
-each month with probability 50%. Without the last row, Exit would be<br />
-<em>absorbing</em> — once there, the chain stays — and the entire team would<br />
+<p>The first three rows encode promotion and attrition rates per career level.
+The last row models <em>replacement hiring</em>: an Exit slot returns to Junior
+each month with probability 50%. Without the last row, Exit would be
+<em>absorbing</em> — once there, the chain stays — and the entire team would
 eventually leave.</p>
 <h3 id="mathinline55a049b8f161ae7cfeb0197d75aff967-step-transitions">$n$-step transitions</h3>
-<p>The probability of going from state $i$ to state $j$ in $n$ months is the<br />
-$(i, j)$-entry of $P^n$. To prove this, condition on the intermediate state<br />
+<p>The probability of going from state $i$ to state $j$ in $n$ months is the
+$(i, j)$-entry of $P^n$. To prove this, condition on the intermediate state
 at time $n$:</p>
 <p>$$
 p_{ij}^{(m+n)}  =  \sum_{k} p_{ik}^{(m)} \, p_{kj}^{(n)}.
 $$</p>
-<p>This is the <strong>Chapman–Kolmogorov equation</strong>, the probabilistic content of<br />
-matrix multiplication associativity $P^{m+n} = P^m P^n$. Iteration of one<br />
+<p>This is the <strong>Chapman–Kolmogorov equation</strong>, the probabilistic content of
+matrix multiplication associativity $P^{m+n} = P^m P^n$. Iteration of one
 step at a time is the same as one big matrix power.</p>
 <h3 id="classification-of-states">Classification of states</h3>
-<p>Two states <strong>communicate</strong> ($i \leftrightarrow j$) if each can be reached<br />
-from the other in finitely many steps. Communication is an equivalence<br />
-relation, partitioning the state space into <strong>communication classes</strong>. A<br />
+<p>Two states <strong>communicate</strong> ($i \leftrightarrow j$) if each can be reached
+from the other in finitely many steps. Communication is an equivalence
+relation, partitioning the state space into <strong>communication classes</strong>. A
 chain is <strong>irreducible</strong> when there is one class.</p>
-<p>A state is <strong>recurrent</strong> if the chain returns to it with probability 1, and<br />
-<strong>transient</strong> otherwise. <strong>Absorbing</strong> states are the extreme case of<br />
-recurrence — once in, never out. The headcount chain with replacement<br />
-hiring is irreducible: from any career level, every other state is<br />
-reachable. Cut the recycling rate to zero (set $p_{41} = 0$) and the chain<br />
+<p>A state is <strong>recurrent</strong> if the chain returns to it with probability 1, and
+<strong>transient</strong> otherwise. <strong>Absorbing</strong> states are the extreme case of
+recurrence — once in, never out. The headcount chain with replacement
+hiring is irreducible: from any career level, every other state is
+reachable. Cut the recycling rate to zero (set $p_{41} = 0$) and the chain
 becomes absorbing — Exit traps the dynamics.</p>
-<p>The two variants split the work between the next two sections. With the<br />
-matrix $P$ in hand, we can ask two things a deterministic plan cannot<br />
-answer. First, <em>if the current rates persist, what distribution does the<br />
-team converge to?</em> — that is the irreducible variant and<br />
-<a href="#where-will-the-team-settle">the stationary analysis</a>. Second, <em>how long<br />
-does an extreme scenario take? how long for a Junior to reach Senior, or<br />
-how long until the team empties under a hiring freeze?</em> — that is the<br />
-absorbing variant and <a href="#how-long-will-it-take">the hitting-time analysis</a>.<br />
+<p>The two variants split the work between the next two sections. With the
+matrix $P$ in hand, we can ask two things a deterministic plan cannot
+answer. First, <em>if the current rates persist, what distribution does the
+team converge to?</em> — that is the irreducible variant and
+<a href="#where-will-the-team-settle">the stationary analysis</a>. Second, <em>how long
+does an extreme scenario take? how long for a Junior to reach Senior, or
+how long until the team empties under a hiring freeze?</em> — that is the
+absorbing variant and <a href="#how-long-will-it-take">the hitting-time analysis</a>.
 Both answers come from the same matrix $P$ via linear-algebra computations.</p>
 <hr />
 <h2 id="where-will-the-team-settle">Where Will the Team Settle?</h2>
-<p>A row vector $\pi = (\pi_1, \ldots, \pi_K)$ is a <strong>stationary<br />
+<p>A row vector $\pi = (\pi_1, \ldots, \pi_K)$ is a <strong>stationary
 distribution</strong> if it satisfies</p>
 <p>$$
 \pi P  =  \pi, \qquad \pi_i \geq 0, \qquad \sum_i \pi_i  =  1.
 $$</p>
-<p>Started in $\pi$, the chain stays in $\pi$ forever. The question of this<br />
-section is: under what conditions does $\pi$ exist, when is it unique, and<br />
+<p>Started in $\pi$, the chain stays in $\pi$ forever. The question of this
+section is: under what conditions does $\pi$ exist, when is it unique, and
 how fast does an arbitrary starting distribution converge to it?</p>
 <h3 id="existence">Existence</h3>
-<p>For a finite irreducible Markov chain a stationary distribution <strong>always<br />
+<p>For a finite irreducible Markov chain a stationary distribution <strong>always
 exists</strong>. The proof uses the Cesàro average</p>
 <p>$$
 \bar\pi_n  =  \frac{1}{n} \sum_{k=0}^{n-1} e_i P^k.
 $$</p>
-<p>Each $\bar\pi_n$ lies in the probability simplex, which is compact. By the<br />
-Bolzano–Weierstrass theorem, a subsequence converges to some $\pi^* \in<br />
-\Delta_K$. A short calculation shows $\bar\pi_n P - \bar\pi_n \to 0$, so<br />
+<p>Each $\bar\pi_n$ lies in the probability simplex, which is compact. By the
+Bolzano–Weierstrass theorem, a subsequence converges to some $\pi^* \in
+\Delta_K$. A short calculation shows $\bar\pi_n P - \bar\pi_n \to 0$, so
 $\pi^* P = \pi^*$ — the limit is stationary.</p>
 <h3 id="uniqueness-and-perronfrobenius">Uniqueness and Perron–Frobenius</h3>
-<p>For an irreducible aperiodic finite chain, $\pi$ is <strong>unique</strong>. The cleanest<br />
-way to see this is via the spectral structure of $P$. The Perron–Frobenius<br />
+<p>For an irreducible aperiodic finite chain, $\pi$ is <strong>unique</strong>. The cleanest
+way to see this is via the spectral structure of $P$. The Perron–Frobenius
 theorem says:</p>
 <ol>
 <li>Every eigenvalue $\lambda$ of $P$ satisfies $|\lambda| \leq 1$.</li>
-<li>$\lambda = 1$ is a simple eigenvalue (multiplicity 1) for an irreducible<br />
+<li>$\lambda = 1$ is a simple eigenvalue (multiplicity 1) for an irreducible
    aperiodic chain.</li>
-<li>The unique left eigenvector for $\lambda = 1$, normalised to a<br />
+<li>The unique left eigenvector for $\lambda = 1$, normalised to a
    probability vector, is $\pi$ — and $\pi_i > 0$ for all $i$.</li>
 </ol>
-<p>The second eigenvalue $\lambda_2$ governs the rate of convergence. Decompose<br />
+<p>The second eigenvalue $\lambda_2$ governs the rate of convergence. Decompose
 $P$ spectrally:</p>
 <p>$$
 P^n  =  \mathbf{1}\pi + \sum_{k \geq 2} \lambda_k^n \, u_k v_k^\top.
 $$</p>
-<p>Since $|\lambda_k| < 1$ for $k \geq 2$, the non-stationary terms decay<br />
+<p>Since $|\lambda_k| < 1$ for $k \geq 2$, the non-stationary terms decay
 geometrically. We get the bound</p>
 <p>$$
 \|P^n - \mathbf{1}\pi\|  \leq  C \cdot |\lambda_2|^n.
 $$</p>
-<p>The <strong>spectral gap</strong> $\gamma = 1 - |\lambda_2|$ is the inverse-time-scale of<br />
-forgetting. A gap close to 1 means the chain mixes fast; a gap close to 0<br />
+<p>The <strong>spectral gap</strong> $\gamma = 1 - |\lambda_2|$ is the inverse-time-scale of
+forgetting. A gap close to 1 means the chain mixes fast; a gap close to 0
 means the initial condition lingers.</p>
-<p><strong>What this means for workforce planning.</strong> The spectral gap is <em>the<br />
-single number</em> that tells you how long "long run" actually takes. If<br />
-$\gamma = 0.5$, the chain halves its distance from $\pi$ every two<br />
-months. If $\gamma = 0.01$, every $\sim 70$ months. For most realistic<br />
-workforce chains — promotion and attrition rates of a few percent per<br />
-month — the gap is small, and the long run is <em>years</em>, not quarters. The<br />
-practical implication is uncomfortable: the stationary distribution is<br />
-not a destination you reach within a planning cycle. It is a compass<br />
-that tells you where your current rates are pointing the team, even<br />
+<p><strong>What this means for workforce planning.</strong> The spectral gap is <em>the
+single number</em> that tells you how long "long run" actually takes. If
+$\gamma = 0.5$, the chain halves its distance from $\pi$ every two
+months. If $\gamma = 0.01$, every $\sim 70$ months. For most realistic
+workforce chains — promotion and attrition rates of a few percent per
+month — the gap is small, and the long run is <em>years</em>, not quarters. The
+practical implication is uncomfortable: the stationary distribution is
+not a destination you reach within a planning cycle. It is a compass
+that tells you where your current rates are pointing the team, even
 though the team will not arrive on the planner's timetable.</p>
 <h3 id="the-headcount-steady-state">The headcount steady state</h3>
-<p>For the recycling chain, $\pi P = \pi$ is solvable by hand. The second<br />
-equation gives $\pi_M = \tfrac{3}{4} \pi_J$, the third gives<br />
-$\pi_S = \tfrac{3}{2} \pi_J$, the fourth gives $\pi_E = 0.14 \, \pi_J$.<br />
+<p>For the recycling chain, $\pi P = \pi$ is solvable by hand. The second
+equation gives $\pi_M = \tfrac{3}{4} \pi_J$, the third gives
+$\pi_S = \tfrac{3}{2} \pi_J$, the fourth gives $\pi_E = 0.14 \, \pi_J$.
 Normalising,</p>
 <p>$$
 \pi  \approx  (0.295,   0.221,   0.443,   0.041).
 $$</p>
-<p>In the long run, an employee spends about 30% of his months as Junior, 22%<br />
-as Mid, 44% as Senior, and 4% in transit through Exit. The Senior fraction<br />
-dominates because the Senior attrition rate ($p_{34} = 0.01$) is the lowest<br />
+<p>In the long run, an employee spends about 30% of his months as Junior, 22%
+as Mid, 44% as Senior, and 4% in transit through Exit. The Senior fraction
+dominates because the Senior attrition rate ($p_{34} = 0.01$) is the lowest
 of all rates — Seniors linger.</p>
-<p>The eigenvalues of $P$ are approximately<br />
-$\{1.00,   0.99,   0.94,   0.41\}$. The spectral gap is<br />
-$\gamma \approx 0.01$, giving a mixing time of order $1/\gamma \approx 100$<br />
-months. Empirically, the total-variation distance falls below $1/4$ around<br />
+<p>The eigenvalues of $P$ are approximately
+$\{1.00,   0.99,   0.94,   0.41\}$. The spectral gap is
+$\gamma \approx 0.01$, giving a mixing time of order $1/\gamma \approx 100$
+months. Empirically, the total-variation distance falls below $1/4$ around
 month 70. The "long-run" composition is a six-year horizon for this chain.</p>
 <figure><img src="../figures/headcount-dynamics/transition_convergence_heatmap.png" alt="Convergence of $P^n$ to the rank-1 stationary matrix" loading="lazy"><figcaption>Convergence of $P^n$ to the rank-1 stationary matrix</figcaption></figure>
-<p>The figure shows $P^n$ for $n = 1, 5, 10, 50, 100$ alongside the limiting<br />
-matrix $\mathbf{1}\pi$. Each row of $P^n$ approaches $\pi$ as $n$ grows,<br />
+<p>The figure shows $P^n$ for $n = 1, 5, 10, 50, 100$ alongside the limiting
+matrix $\mathbf{1}\pi$. Each row of $P^n$ approaches $\pi$ as $n$ grows,
 and by $n = 100$ the rows are visually indistinguishable from the limit.</p>
 <figure><img src="../figures/headcount-dynamics/eigenvalue_spectrum.png" alt="Eigenvalue spectrum and spectral gap" loading="lazy"><figcaption>Eigenvalue spectrum and spectral gap</figcaption></figure>
-<p>The spectrum sits inside the unit disk. The dominant eigenvalue is $1$<br />
-(green); the second-largest in modulus, $\lambda_2 \approx 0.99$ (red),<br />
-sets the rate of convergence. A gap of 0.01 is small — typical for<br />
-real-world workforce chains where promotion and attrition rates are a few<br />
+<p>The spectrum sits inside the unit disk. The dominant eigenvalue is $1$
+(green); the second-largest in modulus, $\lambda_2 \approx 0.99$ (red),
+sets the rate of convergence. A gap of 0.01 is small — typical for
+real-world workforce chains where promotion and attrition rates are a few
 percent per month — and is the reason mixing takes years.</p>
 <hr />
 <h2 id="how-long-will-it-take">How Long Will It Take?</h2>
-<p>The stationary distribution describes where the chain ends up. It says<br />
-nothing about how <em>transient</em> behaviour evolves — the trajectory before the<br />
-asymptote. This section answers questions such as "if hiring stops, how<br />
-many months until the team drops below 40?" and "what fraction of Juniors<br />
-ever reach Senior?". The single object that answers both is the<br />
+<p>The stationary distribution describes where the chain ends up. It says
+nothing about how <em>transient</em> behaviour evolves — the trajectory before the
+asymptote. This section answers questions such as "if hiring stops, how
+many months until the team drops below 40?" and "what fraction of Juniors
+ever reach Senior?". The single object that answers both is the
 <strong>fundamental matrix</strong>.</p>
 <h3 id="the-canonical-form">The canonical form</h3>
-<p>Set $p_{41} = 0$ in the headcount chain to make Exit absorbing. Order the<br />
-states so transients come first, absorbing last. The transition matrix<br />
+<p>Set $p_{41} = 0$ in the headcount chain to make Exit absorbing. Order the
+states so transients come first, absorbing last. The transition matrix
 takes the <strong>canonical form</strong></p>
 <p>$$
 P  =  \begin{pmatrix} Q & R \\ 0 & I \end{pmatrix},
 $$</p>
-<p>where $Q$ is the transient-to-transient block, $R$ is the<br />
-transient-to-absorbing block, and the absorbing block is simply the<br />
+<p>where $Q$ is the transient-to-transient block, $R$ is the
+transient-to-absorbing block, and the absorbing block is simply the
 identity. For the headcount chain with Exit absorbing,</p>
 <p>$$
 Q  =  \begin{pmatrix} 0.93 & 0.03 & 0 \\ 0 & 0.96 & 0.02 \\ 0 & 0 & 0.99 \end{pmatrix}, \qquad
 R  =  \begin{pmatrix} 0.04 \\ 0.02 \\ 0.01 \end{pmatrix}.
 $$</p>
 <h3 id="the-fundamental-matrix">The fundamental matrix</h3>
-<p>Because the chain reaches an absorbing state with probability 1, $Q^n \to 0$<br />
+<p>Because the chain reaches an absorbing state with probability 1, $Q^n \to 0$
 as $n \to \infty$. This implies $\rho(Q) < 1$, so $I - Q$ is invertible and</p>
 <p>$$
 N  =  (I - Q)^{-1}  =  \sum_{k=0}^\infty Q^k.
 $$</p>
-<p>The matrix $N$ is the <strong>fundamental matrix</strong>. Each entry has a probabilistic<br />
-interpretation: $N_{ij}$ is the <em>expected number of months</em> spent in<br />
-transient state $j$ before absorption, given start at $i$. The expected<br />
+<p>The matrix $N$ is the <strong>fundamental matrix</strong>. Each entry has a probabilistic
+interpretation: $N_{ij}$ is the <em>expected number of months</em> spent in
+transient state $j$ before absorption, given start at $i$. The expected
 time to absorption from state $i$ is the sum of all such visits:</p>
 <p>$$
 t  =  N \mathbf{1}.
 $$</p>
-<p>For the headcount chain with Exit absorbing, $N$ is upper triangular with<br />
+<p>For the headcount chain with Exit absorbing, $N$ is upper triangular with
 diagonal entries $1/0.07,   1/0.04,   1/0.01$, and</p>
 <p>$$
 t  =  \begin{pmatrix} 46.4 \\ 75.0 \\ 100.0 \end{pmatrix}  \text{months}.
 $$</p>
-<p>A starting Junior expects roughly 46 months until exit; a Senior, exactly<br />
-$1/0.01 = 100$ months — that is, 100 months in expectation, with<br />
+<p>A starting Junior expects roughly 46 months until exit; a Senior, exactly
+$1/0.01 = 100$ months — that is, 100 months in expectation, with
 geometric-distribution variance.</p>
 <figure><img src="../figures/headcount-dynamics/absorption_times.png" alt="Expected absorption time per starting level, with $\pm 1\sigma$ error bars" loading="lazy"><figcaption>Expected absorption time per starting level, with $\pm 1\sigma$ error bars</figcaption></figure>
-<p>The bars show $t_i$ for each starting level under the absorbing variant.<br />
-The error bars are $\pm 1$ standard deviation, computed from the<br />
-fundamental-matrix variance formula $\mathrm{Var}(T) = (2N - I) t - t \odot t$.<br />
-Senior tenure is roughly twice Junior tenure but with proportionally larger<br />
+<p>The bars show $t_i$ for each starting level under the absorbing variant.
+The error bars are $\pm 1$ standard deviation, computed from the
+fundamental-matrix variance formula $\mathrm{Var}(T) = (2N - I) t - t \odot t$.
+Senior tenure is roughly twice Junior tenure but with proportionally larger
 spread.</p>
 <h3 id="absorption-probabilities-and-first-passage">Absorption probabilities and first passage</h3>
-<p>When the chain has multiple absorbing states, the <strong>absorption probability<br />
-matrix</strong> $B = NR$ tells us where the chain ends up. To compute the<br />
-probability that a Junior ever reaches Senior in the absorbing variant,<br />
-modify the chain so that <em>both</em> Senior and Exit are absorbing, then read<br />
+<p>When the chain has multiple absorbing states, the <strong>absorption probability
+matrix</strong> $B = NR$ tells us where the chain ends up. To compute the
+probability that a Junior ever reaches Senior in the absorbing variant,
+modify the chain so that <em>both</em> Senior and Exit are absorbing, then read
 the relevant column of $B$. The result is</p>
 <p>$$
 P(\text{Junior reaches Senior eventually})  \approx  0.214.
 $$</p>
-<p>Only one Junior in five reaches Senior under the default rates; the rest<br />
+<p>Only one Junior in five reaches Senior under the default rates; the rest
 exit first. For a starting Mid the figure is exactly $0.5$.</p>
 <h3 id="bridge-to-the-stationary-picture-mean-return-times">Bridge to the stationary picture: mean return times</h3>
-<p>For an irreducible chain (the recycling variant), the mean time to <em>return</em><br />
+<p>For an irreducible chain (the recycling variant), the mean time to <em>return</em>
 to a state equals the reciprocal of its stationary probability:</p>
 <p>$$
 \mathbb{E}[T_i \mid X_0 = i]  =  \frac{1}{\pi_i}.
 $$</p>
-<p>This is the bridge between the stationary and the transient analyses. The<br />
-stationary distribution and the mean return times are the same data in two<br />
-different languages. Recurrence and absorption are the two faces of the<br />
-transient picture: a chain in equilibrium returns infinitely often; an<br />
+<p>This is the bridge between the stationary and the transient analyses. The
+stationary distribution and the mean return times are the same data in two
+different languages. Recurrence and absorption are the two faces of the
+transient picture: a chain in equilibrium returns infinitely often; an
 absorbing chain leaves once and never comes back.</p>
 <hr />
 <h2 id="birth-death-processes">Birth-Death Processes</h2>
-<p>Months are an artefact of when we compute payroll. Hiring and attrition<br />
-<em>happen</em> continuously: a resignation can land on the 14th, an offer can be<br />
-signed on the 22nd. To model that, we move from month-by-month snapshots to<br />
+<p>Months are an artefact of when we compute payroll. Hiring and attrition
+<em>happen</em> continuously: a resignation can land on the 14th, an offer can be
+signed on the 22nd. To model that, we move from month-by-month snapshots to
 continuous-time Markov chains (CTMCs).</p>
 <h3 id="generator-matrices">Generator matrices</h3>
-<p>A time-homogeneous CTMC on state space $S$ has a <strong>generator matrix</strong> $Q$<br />
-where $Q_{ij}$ is the <em>rate</em> of transition from $i$ to $j$ for $i \neq j$,<br />
-and $Q_{ii} = -\sum_{j \neq i} Q_{ij}$. Each row sums to zero (rather than<br />
-one, as in the discrete case). Differentiating the obvious identity<br />
-$P(t)\mathbf{1} = \mathbf{1}$ at $t = 0$ gives this row-sum-zero property<br />
+<p>A time-homogeneous CTMC on state space $S$ has a <strong>generator matrix</strong> $Q$
+where $Q_{ij}$ is the <em>rate</em> of transition from $i$ to $j$ for $i \neq j$,
+and $Q_{ii} = -\sum_{j \neq i} Q_{ij}$. Each row sums to zero (rather than
+one, as in the discrete case). Differentiating the obvious identity
+$P(t)\mathbf{1} = \mathbf{1}$ at $t = 0$ gives this row-sum-zero property
 immediately.</p>
-<p>The transition probabilities $P(t) = (p_{ij}(t))$ satisfy the <strong>Kolmogorov<br />
+<p>The transition probabilities $P(t) = (p_{ij}(t))$ satisfy the <strong>Kolmogorov
 forward equation</strong></p>
 <p>$$
 \frac{d}{dt} P(t)  =  P(t) \, Q,
 $$</p>
-<p>with initial condition $P(0) = I$. The unique solution is the matrix<br />
+<p>with initial condition $P(0) = I$. The unique solution is the matrix
 exponential</p>
 <p>$$
 P(t)  =  e^{Qt}  =  \sum_{k = 0}^\infty \frac{(Qt)^k}{k!}.
 $$</p>
-<p>Numerically, <code>scipy.linalg.expm</code> computes $e^{Qt}$ via Padé approximation;<br />
+<p>Numerically, <code>scipy.linalg.expm</code> computes $e^{Qt}$ via Padé approximation;
 this is the workhorse of the rest of the section.</p>
 <h3 id="birth-death-processes_1">Birth-death processes</h3>
-<p>A <strong>birth-death process</strong> is a CTMC on $\{0, 1, 2, \ldots\}$ with only<br />
-nearest-neighbour transitions: a <em>birth</em> moves $n \to n+1$ at rate<br />
-$\lambda_n$, a <em>death</em> moves $n \to n-1$ at rate $\mu_n$. The generator is<br />
-tridiagonal. Headcount fits naturally: a hire is a birth, a resignation is a<br />
+<p>A <strong>birth-death process</strong> is a CTMC on $\{0, 1, 2, \ldots\}$ with only
+nearest-neighbour transitions: a <em>birth</em> moves $n \to n+1$ at rate
+$\lambda_n$, a <em>death</em> moves $n \to n-1$ at rate $\mu_n$. The generator is
+tridiagonal. Headcount fits naturally: a hire is a birth, a resignation is a
 death.</p>
 <p>The stationary distribution satisfies the <strong>detailed balance</strong> equations</p>
 <p>$$
 \pi_n \, \lambda_n  =  \pi_{n+1} \, \mu_{n+1},
 $$</p>
-<p>— probability flow from $n$ to $n+1$ equals flow back. Solving the<br />
+<p>— probability flow from $n$ to $n+1$ equals flow back. Solving the
 recurrence yields</p>
 <p>$$
 \pi_n  =  \pi_0 \prod_{k = 0}^{n-1} \frac{\lambda_k}{\mu_{k+1}}.
 $$</p>
-<p>A particularly clean special case is <strong>constant hiring with per-capita<br />
+<p>A particularly clean special case is <strong>constant hiring with per-capita
 attrition</strong>: $\lambda_n = \lambda$ and $\mu_n = n\mu$. Then</p>
 <p>$$
 \pi_n  =  e^{-\rho} \frac{\rho^n}{n!}, \qquad \rho  =  \frac{\lambda}{\mu}.
 $$</p>
-<p>The team size is <strong>Poisson</strong> with mean $\rho$. Constant hiring at rate<br />
-$\lambda$ per month and per-capita attrition $\mu$ per month produce a team<br />
-size that, in equilibrium, behaves exactly like the arrival count of a<br />
+<p>The team size is <strong>Poisson</strong> with mean $\rho$. Constant hiring at rate
+$\lambda$ per month and per-capita attrition $\mu$ per month produce a team
+size that, in equilibrium, behaves exactly like the arrival count of a
 Poisson process.</p>
 <h3 id="the-expected-trajectory">The expected trajectory</h3>
-<p>Taking expectations on both sides of the birth-death rate equation gives the<br />
+<p>Taking expectations on both sides of the birth-death rate equation gives the
 ODE</p>
 <p>$$
 \frac{d}{dt} \mathbb{E}[X_t]  =  \lambda - \mu \mathbb{E}[X_t],
@@ -637,30 +637,30 @@ $$</p>
 <p>$$
 \mathbb{E}[X_t]  =  \rho + (n_0 - \rho) \, e^{-\mu t}.
 $$</p>
-<p>The mean exponentially relaxes to the asymptote $\rho$ with half-life<br />
-$\ln 2 / \mu$. With $\mu = 0.025$, the half-life is about 27.7 months —<br />
+<p>The mean exponentially relaxes to the asymptote $\rho$ with half-life
+$\ln 2 / \mu$. With $\mu = 0.025$, the half-life is about 27.7 months —
 over two years. The team forgets its initial size at this rate.</p>
 <h3 id="the-headcount-birth-death">The headcount birth-death</h3>
-<p>For an IT team with $\lambda = 2$ hires per month and per-capita attrition<br />
+<p>For an IT team with $\lambda = 2$ hires per month and per-capita attrition
 $\mu = 0.025$, the asymptotic mean is $\rho = 80$. Starting from $n_0 = 45$,</p>
 <p>$$
 \mathbb{E}[X_{12}]  \approx  54, \qquad P(X_{12} \geq 50 \mid X_0 = 45)  \approx  0.80.
 $$</p>
-<p>There is a 20% chance of finishing the year below 50 — a fact the<br />
+<p>There is a 20% chance of finishing the year below 50 — a fact the
 deterministic forecast $\mathbb{E}[X_{12}] = 54$ entirely conceals.</p>
 <figure><img src="../figures/headcount-dynamics/birth_death_stationary.png" alt="Birth-death stationary: $\pi_n$ is Poisson($\rho$)" loading="lazy"><figcaption>Birth-death stationary: $\pi_n$ is Poisson($\rho$)</figcaption></figure>
-<p>The bars show the analytical detailed-balance distribution; the red line is<br />
-the Poisson PMF with mean $\rho = 80$. They coincide to numerical<br />
+<p>The bars show the analytical detailed-balance distribution; the red line is
+the Poisson PMF with mean $\rho = 80$. They coincide to numerical
 precision.</p>
 <figure><img src="../figures/headcount-dynamics/kolmogorov_trajectory.png" alt="Kolmogorov trajectory with 5–95% band" loading="lazy"><figcaption>Kolmogorov trajectory with 5–95% band</figcaption></figure>
-<p>The expected trajectory $\mathbb{E}[X_t]$ matches the closed-form ODE<br />
-(dashed). The shaded band is the exact 5th–95th-percentile envelope<br />
+<p>The expected trajectory $\mathbb{E}[X_t]$ matches the closed-form ODE
+(dashed). The shaded band is the exact 5th–95th-percentile envelope
 computed from the truncated CTMC's transient distribution at each $t$.</p>
 <hr />
 <h2 id="the-headcount-model">The Headcount Model</h2>
-<p>The previous sections built the apparatus. This section applies it. We<br />
-define a combined <code>HeadcountModel</code> that wraps a discrete-time chain<br />
-(career-level composition) and a birth-death process (total team size),<br />
+<p>The previous sections built the apparatus. This section applies it. We
+define a combined <code>HeadcountModel</code> that wraps a discrete-time chain
+(career-level composition) and a birth-death process (total team size),
 and run five scenarios that a real planner would face.</p>
 <h3 id="the-combined-model">The combined model</h3>
 <p>The <code>HeadcountModel</code> answers planning questions through six methods:</p>
@@ -698,194 +698,194 @@ and run five scenarios that a real planner would face.</p>
 </tr>
 </tbody>
 </table>
-<p>The composition (DTMC) and the team size (birth-death) are treated as<br />
+<p>The composition (DTMC) and the team size (birth-death) are treated as
 independent processes. This decoupling is a deliberate simplification.</p>
-<p><strong>When the simplification is fine.</strong> When attrition rates are roughly<br />
-similar across levels (Junior, Mid, and Senior), team size depends on the<br />
-<em>total</em> outflow and is well-approximated by the birth-death model with a<br />
-single per-capita $\mu$. Composition then evolves on top of size without<br />
-materially feeding back. The <a href="#experiments-and-results">experiments</a> show<br />
-that for the default rates the two processes track Monte Carlo ground<br />
+<p><strong>When the simplification is fine.</strong> When attrition rates are roughly
+similar across levels (Junior, Mid, and Senior), team size depends on the
+<em>total</em> outflow and is well-approximated by the birth-death model with a
+single per-capita $\mu$. Composition then evolves on top of size without
+materially feeding back. The <a href="#experiments-and-results">experiments</a> show
+that for the default rates the two processes track Monte Carlo ground
 truth within sampling error.</p>
 <p><strong>When it breaks.</strong> Three regimes deserve a more refined model:</p>
 <ol>
-<li><strong>Strongly heterogeneous attrition.</strong> If Senior attrition were 0.001<br />
-   and Junior attrition 0.10 (a 100× ratio), team size and composition<br />
-   become coupled through the population-weighted attrition rate<br />
-   $\sum_i \pi_i \mu_i$. Independent factoring underestimates the<br />
+<li><strong>Strongly heterogeneous attrition.</strong> If Senior attrition were 0.001
+   and Junior attrition 0.10 (a 100× ratio), team size and composition
+   become coupled through the population-weighted attrition rate
+   $\sum_i \pi_i \mu_i$. Independent factoring underestimates the
    variance of total size.</li>
-<li><strong>Capacity constraints.</strong> A hiring budget that scales with revenue<br />
-   (typical at growing companies) ties hiring rate $\lambda$ back to<br />
-   composition through productivity assumptions. The simplification<br />
+<li><strong>Capacity constraints.</strong> A hiring budget that scales with revenue
+   (typical at growing companies) ties hiring rate $\lambda$ back to
+   composition through productivity assumptions. The simplification
    ignores this loop.</li>
-<li><strong>Cohort effects.</strong> New hires churn at higher rates than tenured<br />
-   employees during the first six months. The Markov property assumes<br />
-   memorylessness, so the chain <em>cannot</em> represent tenure-dependent<br />
+<li><strong>Cohort effects.</strong> New hires churn at higher rates than tenured
+   employees during the first six months. The Markov property assumes
+   memorylessness, so the chain <em>cannot</em> represent tenure-dependent
    attrition without expanding the state space.</li>
 </ol>
-<p>For the default IT-team parameters used here, the bias is empirically<br />
-about 1–3% on second moments and negligible on means. A real deployment<br />
-should re-validate the assumption against simulation before relying on<br />
+<p>For the default IT-team parameters used here, the bias is empirically
+about 1–3% on second moments and negligible on means. A real deployment
+should re-validate the assumption against simulation before relying on
 the closed forms.</p>
 <h3 id="scenario-s1-steady-growth">Scenario S1 — Steady growth</h3>
 <p><em>Question.</em> "We need to grow from 45 to 60 over twelve months. Achievable?"</p>
-<p>Under the base parameters, $\mathbb{E}[X_{12}] \approx 54$, falling short<br />
-of 60. To reach 60 in expectation, $\lambda$ must rise to $\approx 2.31$<br />
-hires per month — a 16% increase. The figure compares the base case to the<br />
+<p>Under the base parameters, $\mathbb{E}[X_{12}] \approx 54$, falling short
+of 60. To reach 60 in expectation, $\lambda$ must rise to $\approx 2.31$
+hires per month — a 16% increase. The figure compares the base case to the
 boosted case side by side.</p>
 <figure><img src="../figures/headcount-dynamics/scenario_s1_steady_growth.png" alt="Scenario S1 — steady growth" loading="lazy"><figcaption>Scenario S1 — steady growth</figcaption></figure>
-<p>The red dashed line marks the target. The probability of hitting 60 by<br />
-month 12 rises from 0.31 to 0.51 with the hiring boost. This is a 20-point<br />
+<p>The red dashed line marks the target. The probability of hitting 60 by
+month 12 rises from 0.31 to 0.51 with the hiring boost. This is a 20-point
 swing: real money's worth of additional recruitment effort.</p>
 <h3 id="scenario-s2-hiring-freeze">Scenario S2 — Hiring freeze</h3>
 <p><em>Question.</em> "If we freeze hiring today, when do we drop below 40?"</p>
-<p>Set $\lambda = 0$. The mean trajectory becomes pure exponential decay:<br />
-$\mathbb{E}[n(t)] = 45 \, e^{-0.025 t}$, crossing 40 at $t \approx 4.7$<br />
-months. The 5–95% band on the figure adds about $\pm 2$ months of<br />
+<p>Set $\lambda = 0$. The mean trajectory becomes pure exponential decay:
+$\mathbb{E}[n(t)] = 45 \, e^{-0.025 t}$, crossing 40 at $t \approx 4.7$
+months. The 5–95% band on the figure adds about $\pm 2$ months of
 variability around the threshold crossing.</p>
 <figure><img src="../figures/headcount-dynamics/scenario_s2_hiring_freeze.png" alt="Scenario S2 — hiring freeze" loading="lazy"><figcaption>Scenario S2 — hiring freeze</figcaption></figure>
 <h3 id="scenario-s3-layoff-recovery">Scenario S3 — Layoff recovery</h3>
 <p><em>Question.</em> "We just cut to 35 people. How long to recover to 45?"</p>
-<p>Reset $n_0 = 35$ with the original hiring/attrition rates. The mean reaches<br />
-45 in $\ln(45/35) / 0.025 \approx 10$ months. Recovery is faster than the<br />
-half-life because the target is below the asymptote: the chain is <em>pulled<br />
+<p>Reset $n_0 = 35$ with the original hiring/attrition rates. The mean reaches
+45 in $\ln(45/35) / 0.025 \approx 10$ months. Recovery is faster than the
+half-life because the target is below the asymptote: the chain is <em>pulled
 upward</em> by the gap to $\rho = 80$.</p>
 <figure><img src="../figures/headcount-dynamics/scenario_s3_layoff_recovery.png" alt="Scenario S3 — layoff recovery" loading="lazy"><figcaption>Scenario S3 — layoff recovery</figcaption></figure>
 <h3 id="scenario-s4-composition-shift">Scenario S4 — Composition shift</h3>
-<p><em>Question.</em> "We want the steady-state Senior fraction to rise from 44% to<br />
+<p><em>Question.</em> "We want the steady-state Senior fraction to rise from 44% to
 60%. What rate change gets us there?"</p>
-<p>The Senior share is most sensitive to the Senior attrition rate $p_{34}$.<br />
-Halving it (from 0.01 to 0.005) raises $\pi_S$ from 0.44 to 0.59. The<br />
-figure plots $\pi_J, \pi_M, \pi_S$ as functions of $p_{34}$ across a<br />
-realistic range. Doubling $p_{34}$ pushes Senior share down to 0.30 and<br />
+<p>The Senior share is most sensitive to the Senior attrition rate $p_{34}$.
+Halving it (from 0.01 to 0.005) raises $\pi_S$ from 0.44 to 0.59. The
+figure plots $\pi_J, \pi_M, \pi_S$ as functions of $p_{34}$ across a
+realistic range. Doubling $p_{34}$ pushes Senior share down to 0.30 and
 floods Mid; halving it has the opposite effect.</p>
 <figure><img src="../figures/headcount-dynamics/scenario_s4_composition_shift.png" alt="Scenario S4 — composition shift" loading="lazy"><figcaption>Scenario S4 — composition shift</figcaption></figure>
 <h3 id="scenario-s5-seasonal-hiring">Scenario S5 — Seasonal hiring</h3>
-<p><em>Question.</em> "Hiring is bursty: $\lambda = 3$ in Q1 and Q3, $\lambda = 1$ in<br />
+<p><em>Question.</em> "Hiring is bursty: $\lambda = 3$ in Q1 and Q3, $\lambda = 1$ in
 Q2 and Q4. Does the average tell the whole story?"</p>
-<p>The annual mean is unchanged (linearity of expectation), but the variance<br />
-at month 12 is about 6% higher under seasonal hiring than under constant<br />
-$\bar\lambda = 2$. The figure shows the seasonal trajectory tracking the<br />
-constant-$\lambda$ baseline closely on average but with visibly wider 5–95%<br />
+<p>The annual mean is unchanged (linearity of expectation), but the variance
+at month 12 is about 6% higher under seasonal hiring than under constant
+$\bar\lambda = 2$. The figure shows the seasonal trajectory tracking the
+constant-$\lambda$ baseline closely on average but with visibly wider 5–95%
 bands at quarter-end peaks.</p>
 <figure><img src="../figures/headcount-dynamics/scenario_s5_seasonal_hiring.png" alt="Scenario S5 — seasonal hiring" loading="lazy"><figcaption>Scenario S5 — seasonal hiring</figcaption></figure>
 <h3 id="sensitivity-tornado">Sensitivity tornado</h3>
-<p>A planner with limited budget for hiring or retention initiatives needs a<br />
-ranking of which rates matter most. The tornado figure varies each rate by<br />
-$\pm 50\%$ around its base value and ranks parameters by the magnitude of<br />
+<p>A planner with limited budget for hiring or retention initiatives needs a
+ranking of which rates matter most. The tornado figure varies each rate by
+$\pm 50\%$ around its base value and ranks parameters by the magnitude of
 the impact on long-run team size and Senior share.</p>
 <figure><img src="../figures/headcount-dynamics/sensitivity_tornado.png" alt="Sensitivity tornado" loading="lazy"><figcaption>Sensitivity tornado</figcaption></figure>
-<p>The headline findings: $\mu$ has a slightly larger asymmetric impact on<br />
-$\rho = \lambda / \mu$ than $\lambda$ does (because $\rho \propto 1/\mu$).<br />
-Senior share is dominated by Senior attrition — the next-most-important<br />
-rates are upstream promotions, with Junior attrition having the smallest<br />
-effect. The implication for action: Senior retention is the highest-leverage<br />
+<p>The headline findings: $\mu$ has a slightly larger asymmetric impact on
+$\rho = \lambda / \mu$ than $\lambda$ does (because $\rho \propto 1/\mu$).
+Senior share is dominated by Senior attrition — the next-most-important
+rates are upstream promotions, with Junior attrition having the smallest
+effect. The implication for action: Senior retention is the highest-leverage
 investment for shaping team composition.</p>
 <hr />
 <h2 id="experiments-and-results">Experiments and Results</h2>
-<p>Each result in the preceding sections is an analytical claim. This section<br />
-validates each one numerically against simulation, using the standard<br />
-template — <strong>Claim</strong>, <strong>Setup</strong>, <strong>Result</strong>, <strong>Connection</strong>. All<br />
-experiments use a single fixed seed (2026) and a single style module<br />
+<p>Each result in the preceding sections is an analytical claim. This section
+validates each one numerically against simulation, using the standard
+template — <strong>Claim</strong>, <strong>Setup</strong>, <strong>Result</strong>, <strong>Connection</strong>. All
+experiments use a single fixed seed (2026) and a single style module
 (<code>scripts/_style.py</code>) to guarantee reproducibility.</p>
 <h3 id="experiment-a-convergence-of-mathinline48831f58bb64002759cbb324d978522d">Experiment A — Convergence of $P^n$</h3>
-<p><strong>Claim.</strong> $P^n \to \mathbf{1}\pi$ geometrically for an irreducible<br />
+<p><strong>Claim.</strong> $P^n \to \mathbf{1}\pi$ geometrically for an irreducible
 aperiodic chain.</p>
-<p><strong>Setup.</strong> Matrix powers $P^n$ computed at $n = 1, 5, 10, 50, 100$ and<br />
+<p><strong>Setup.</strong> Matrix powers $P^n$ computed at $n = 1, 5, 10, 50, 100$ and
 compared, row by row, against the rank-1 limit $\mathbf{1}\pi$.</p>
-<p><strong>Result.</strong> Each row of $P^n$ approaches $\pi$; by $n = 100$ the rows are<br />
-visually indistinguishable from the limit. Geometric decay at rate<br />
-$|\lambda_2|^n$ means each row halves its distance from $\pi$ every<br />
+<p><strong>Result.</strong> Each row of $P^n$ approaches $\pi$; by $n = 100$ the rows are
+visually indistinguishable from the limit. Geometric decay at rate
+$|\lambda_2|^n$ means each row halves its distance from $\pi$ every
 $\sim \ln 2 / \gamma \approx 70$ months.</p>
-<p><strong>Connection.</strong> The convergence theorem of<br />
-<a href="#where-will-the-team-settle">Where Will the Team Settle?</a> — the heatmap<br />
+<p><strong>Connection.</strong> The convergence theorem of
+<a href="#where-will-the-team-settle">Where Will the Team Settle?</a> — the heatmap
 figure lives there.</p>
 <h3 id="experiment-b-spectral-gap-and-mixing-time">Experiment B — Spectral gap and mixing time</h3>
 <p><strong>Claim.</strong> The spectral gap predicts how long "long run" takes.</p>
-<p><strong>Setup.</strong> Eigenvalues of $P$ computed numerically; empirical mixing time<br />
-defined as the smallest $n$ such that<br />
+<p><strong>Setup.</strong> Eigenvalues of $P$ computed numerically; empirical mixing time
+defined as the smallest $n$ such that
 $\max_i \tfrac{1}{2}\|P^n_{i,:} - \pi\|_1 \leq 1/4$.</p>
-<p><strong>Result.</strong> The gap is $\gamma \approx 0.01$ and the empirical mixing time<br />
-is approximately 70 months. The theoretical bound<br />
-$t_{\mathrm{mix}} \leq (1/\gamma) \ln(1 / (\varepsilon \pi_{\min}))$<br />
+<p><strong>Result.</strong> The gap is $\gamma \approx 0.01$ and the empirical mixing time
+is approximately 70 months. The theoretical bound
+$t_{\mathrm{mix}} \leq (1/\gamma) \ln(1 / (\varepsilon \pi_{\min}))$
 predicts roughly 200 months — loose because $\pi_{\min}$ is small.</p>
-<p><strong>Connection.</strong> Makes the "long run is years, not quarters" claim of<br />
-<a href="#where-will-the-team-settle">the stationary analysis</a> quantitative — the<br />
+<p><strong>Connection.</strong> Makes the "long run is years, not quarters" claim of
+<a href="#where-will-the-team-settle">the stationary analysis</a> quantitative — the
 spectrum figure lives there.</p>
 <h3 id="experiment-c-absorption-times">Experiment C — Absorption times</h3>
-<p><strong>Claim.</strong> The fundamental matrix gives exact expected tenures per starting<br />
+<p><strong>Claim.</strong> The fundamental matrix gives exact expected tenures per starting
 level.</p>
-<p><strong>Setup.</strong> Absorbing variant ($p_{41} = 0$); $t = N\mathbf{1}$ and the<br />
+<p><strong>Setup.</strong> Absorbing variant ($p_{41} = 0$); $t = N\mathbf{1}$ and the
 variance formula $(2N - I)t - t \odot t$ evaluated per level.</p>
-<p><strong>Result.</strong> Expected time to exit: 46 months for Junior, 75 for Mid, 100<br />
-for Senior — with standard deviations 47, 50, 99, so the 1-sigma intervals<br />
-are wide. Senior tenure is geometrically distributed with parameter 0.01:<br />
+<p><strong>Result.</strong> Expected time to exit: 46 months for Junior, 75 for Mid, 100
+for Senior — with standard deviations 47, 50, 99, so the 1-sigma intervals
+are wide. Senior tenure is geometrically distributed with parameter 0.01:
 mean 100, standard deviation 99 — the chain "gambles" on never resigning.</p>
-<p><strong>Connection.</strong> The fundamental-matrix machinery of<br />
-<a href="#how-long-will-it-take">How Long Will It Take?</a> — the bar chart lives<br />
+<p><strong>Connection.</strong> The fundamental-matrix machinery of
+<a href="#how-long-will-it-take">How Long Will It Take?</a> — the bar chart lives
 there.</p>
 <h3 id="experiment-d-birth-death-steady-state">Experiment D — Birth-death steady state</h3>
-<p><strong>Claim.</strong> Under constant hiring and per-capita attrition, the equilibrium<br />
+<p><strong>Claim.</strong> Under constant hiring and per-capita attrition, the equilibrium
 team size is exactly Poisson($\rho$).</p>
-<p><strong>Setup.</strong> Two checks: the analytical detailed-balance distribution against<br />
-the Poisson PMF; and 200 simulated paths over 400 months, first 200 months<br />
+<p><strong>Setup.</strong> Two checks: the analytical detailed-balance distribution against
+the Poisson PMF; and 200 simulated paths over 400 months, first 200 months
 discarded as burn-in, histogram of the remaining samples.</p>
-<p><strong>Result.</strong> The analytical distributions coincide to floating-point<br />
-precision. The empirical mean is 80.33 and variance 80.99, both within 1%<br />
-of the Poisson(80) target; the KS-style<br />
-$\sup |F_{\mathrm{emp}} - F_{\mathrm{Poisson}}|$ is 0.022 — well below<br />
+<p><strong>Result.</strong> The analytical distributions coincide to floating-point
+precision. The empirical mean is 80.33 and variance 80.99, both within 1%
+of the Poisson(80) target; the KS-style
+$\sup |F_{\mathrm{emp}} - F_{\mathrm{Poisson}}|$ is 0.022 — well below
 typical critical values for $N \sim 40\,000$ samples.</p>
-<p><strong>Connection.</strong> The detailed-balance derivation of<br />
+<p><strong>Connection.</strong> The detailed-balance derivation of
 <a href="#birth-death-processes">Birth-Death Processes</a>.</p>
 <figure><img src="../figures/headcount-dynamics/birth_death_steady_simulation.png" alt="Birth-death steady state — empirical histogram vs Poisson" loading="lazy"><figcaption>Birth-death steady state — empirical histogram vs Poisson</figcaption></figure>
 <h3 id="experiment-e-the-five-scenarios">Experiment E — The five scenarios</h3>
-<p><strong>Claim.</strong> The analytical mean and the exact 5–95% band describe what<br />
+<p><strong>Claim.</strong> The analytical mean and the exact 5–95% band describe what
 simulated teams actually do.</p>
-<p><strong>Setup.</strong> Each scenario figure of <a href="#the-headcount-model">The Headcount Model</a><br />
-overlays 30 simulated paths on the analytical mean and the exact band<br />
+<p><strong>Setup.</strong> Each scenario figure of <a href="#the-headcount-model">The Headcount Model</a>
+overlays 30 simulated paths on the analytical mean and the exact band
 derived from the truncated CTMC.</p>
-<p><strong>Result.</strong> The simulated paths visually fill the band in every scenario —<br />
+<p><strong>Result.</strong> The simulated paths visually fill the band in every scenario —
 an end-to-end check of the model's correctness.</p>
 <p><strong>Connection.</strong> Validates the applied model and all five scenario answers.</p>
 <h3 id="experiment-f-sensitivity-tornado">Experiment F — Sensitivity tornado</h3>
 <p><strong>Claim.</strong> A small number of rates dominates long-run size and composition.</p>
-<p><strong>Setup.</strong> Each rate varied by $\pm 50\%$ around its base value; impact on<br />
+<p><strong>Setup.</strong> Each rate varied by $\pm 50\%$ around its base value; impact on
 $\rho$ and on the Senior share ranked by magnitude.</p>
-<p><strong>Result.</strong> Senior attrition $p_{34}$ leads, with<br />
-$|\Delta \pi_S| \approx 0.17$. Next come Mid→Senior promotion ($p_{23}$,<br />
-$\Delta = 0.12$) and Junior→Mid promotion ($p_{12}$, $\Delta = 0.11$). The<br />
-smallest effect is Junior attrition ($\Delta = 0.005$) — counterintuitively<br />
+<p><strong>Result.</strong> Senior attrition $p_{34}$ leads, with
+$|\Delta \pi_S| \approx 0.17$. Next come Mid→Senior promotion ($p_{23}$,
+$\Delta = 0.12$) and Junior→Mid promotion ($p_{12}$, $\Delta = 0.11$). The
+smallest effect is Junior attrition ($\Delta = 0.005$) — counterintuitively
 low, because entry-level churn is largely absorbed by replacement hiring.</p>
-<p><strong>Connection.</strong> Grounds the "which lever to pull" step of<br />
-<a href="#a-practical-framework">A Practical Framework</a> — the tornado figure lives<br />
+<p><strong>Connection.</strong> Grounds the "which lever to pull" step of
+<a href="#a-practical-framework">A Practical Framework</a> — the tornado figure lives
 in <a href="#the-headcount-model">The Headcount Model</a>.</p>
 <h3 id="experiment-g-trajectory-animation">Experiment G — Trajectory animation</h3>
-<p><strong>Claim.</strong> The fan of simulated trajectories is the clearest single<br />
+<p><strong>Claim.</strong> The fan of simulated trajectories is the clearest single
 artefact for non-technical audiences.</p>
-<p><strong>Setup.</strong> An animated GIF reveals 100 simulated trajectories month by<br />
-month, overlaid with the analytical mean and 5–95% band (companion<br />
+<p><strong>Setup.</strong> An animated GIF reveals 100 simulated trajectories month by
+month, overlaid with the analytical mean and 5–95% band (companion
 repository).</p>
-<p><strong>Result.</strong> Paths fan out from $n_0 = 45$, cradled by the band as it<br />
-widens, with the mean curve climbing toward $\rho = 80$. It is the figure<br />
+<p><strong>Result.</strong> Paths fan out from $n_0 = 45$, cradled by the band as it
+widens, with the mean curve climbing toward $\rho = 80$. It is the figure
 most worth showing in a planning meeting.</p>
 <p><strong>Connection.</strong> Everything at once — the visual summary of the whole model.</p>
 <h3 id="cross-cutting-validation">Cross-cutting validation</h3>
-<p>The seven experiments cover every theorem stated in the article. The<br />
-analytical and empirical numbers agree within Monte Carlo error in every<br />
-case. Each script lives in <code>scripts/</code>, uses seed 2026, and is wired to a<br />
+<p>The seven experiments cover every theorem stated in the article. The
+analytical and empirical numbers agree within Monte Carlo error in every
+case. Each script lives in <code>scripts/</code>, uses seed 2026, and is wired to a
 master runner that reproduces all 13 figures with one command.</p>
 <hr />
 <h2 id="the-bridge-to-the-budget">The Bridge to the Budget</h2>
-<p>The companion article,<br />
-<a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a>,<br />
-simulates the total annual budget by sampling headcount and salaries<br />
-jointly — but treats headcount as a fixed input from outside. This article<br />
-supplies precisely what was missing: the <em>distribution</em> of headcount over<br />
-the planning horizon. Together, the two cover the full personnel-budget<br />
+<p>The companion article,
+<a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a>,
+simulates the total annual budget by sampling headcount and salaries
+jointly — but treats headcount as a fixed input from outside. This article
+supplies precisely what was missing: the <em>distribution</em> of headcount over
+the planning horizon. Together, the two cover the full personnel-budget
 problem under uncertainty.</p>
-<p>The closed-form bridge uses the laws of total expectation and total<br />
-variance. Let $N$ = team size at month 12 and $S_i$ = i.i.d. salaries with<br />
-$\mathbb{E}[S] = m$ and $\mathrm{Var}[S] = v$. Total annual salary cost is<br />
+<p>The closed-form bridge uses the laws of total expectation and total
+variance. Let $N$ = team size at month 12 and $S_i$ = i.i.d. salaries with
+$\mathbb{E}[S] = m$ and $\mathrm{Var}[S] = v$. Total annual salary cost is
 $C = 12 \sum_{i=1}^N S_i$ — random in both $N$ and $S$. Then</p>
 <p>$$
 \mathbb{E}[C]  =  12 \, \mathbb{E}[N] \, m,
@@ -893,48 +893,48 @@ $$</p>
 <p>$$
 \mathrm{Var}[C]  =  144 \, \bigl( \mathbb{E}[N]^2 \, v + m^2 \, \mathrm{Var}[N] + \mathrm{Var}[N] \cdot v \bigr).
 $$</p>
-<p>Numerical example. Use the default headcount chain ($n_0 = 45$, $\lambda =<br />
-2$, $\mu = 0.025$) and a salary distribution<br />
-$S \sim \mathrm{LogNormal}(9.2, 0.30)$. Then $\mathbb{E}[N] \approx 54$ and<br />
-$\mathrm{Var}[N] \approx 35$ at month 12 (computed exactly from the<br />
-truncated CTMC). The salary moments are $m \approx 10\,432$ and<br />
+<p>Numerical example. Use the default headcount chain ($n_0 = 45$, $\lambda =
+2$, $\mu = 0.025$) and a salary distribution
+$S \sim \mathrm{LogNormal}(9.2, 0.30)$. Then $\mathbb{E}[N] \approx 54$ and
+$\mathrm{Var}[N] \approx 35$ at month 12 (computed exactly from the
+truncated CTMC). The salary moments are $m \approx 10\,432$ and
 $v \approx 1.02 \times 10^7$. Plugging in:</p>
 <p>$$
 \mathbb{E}[C]  \approx  6.76 \,\mathrm{M}, \qquad \mathrm{sd}(C)  \approx  0.86 \,\mathrm{M}.
 $$</p>
-<p>These are the same numbers the companion's Monte Carlo recovers within<br />
-sampling error. The closed form derived here is fast and exact to second<br />
-order; the Monte Carlo of the companion is needed for full distributions,<br />
-percentiles, and tail probabilities. The two articles compose: this one<br />
-supplies the headcount distribution ($\mathbb{E}[N]$, $\mathrm{Var}[N]$);<br />
-the companion simulates the joint object that includes correlation across<br />
+<p>These are the same numbers the companion's Monte Carlo recovers within
+sampling error. The closed form derived here is fast and exact to second
+order; the Monte Carlo of the companion is needed for full distributions,
+percentiles, and tail probabilities. The two articles compose: this one
+supplies the headcount distribution ($\mathbb{E}[N]$, $\mathrm{Var}[N]$);
+the companion simulates the joint object that includes correlation across
 employees and within-month dependencies.</p>
 <hr />
 <h2 id="a-practical-framework">A Practical Framework</h2>
-<p>A planner who wants to start using the toolkit doesn't need every theorem<br />
+<p>A planner who wants to start using the toolkit doesn't need every theorem
 in this article. They need a short process.</p>
-<p><strong>1. Define the chain.</strong> List the career levels that matter (Junior, Mid,<br />
-Senior, or whatever your organisation calls them) plus an Exit state.<br />
-Estimate monthly transition rates from the last 12–24 months of HR data:<br />
-the fraction of Juniors promoted, the fraction who left, etc. Rates of a<br />
+<p><strong>1. Define the chain.</strong> List the career levels that matter (Junior, Mid,
+Senior, or whatever your organisation calls them) plus an Exit state.
+Estimate monthly transition rates from the last 12–24 months of HR data:
+the fraction of Juniors promoted, the fraction who left, etc. Rates of a
 few percent per month are typical.</p>
-<p><strong>2. Solve the steady state.</strong> Compute $\pi$ via $\pi P = \pi$ (one line of<br />
-NumPy). This tells you the long-run team composition under current rates.<br />
-If $\pi$ doesn't match your aspirations, the rates are the lever — not<br />
+<p><strong>2. Solve the steady state.</strong> Compute $\pi$ via $\pi P = \pi$ (one line of
+NumPy). This tells you the long-run team composition under current rates.
+If $\pi$ doesn't match your aspirations, the rates are the lever — not
 quarterly hiring decisions.</p>
 <p><strong>3. Solve the transient.</strong> Pick a question:</p>
 <ul>
 <li><em>Probability of hitting target</em>: compute $P(n(t) \geq T)$ from $e^{Qt}$.</li>
 <li><em>Time to target</em>: solve the closed-form ODE for $\mathbb{E}[n(t)]$.</li>
-<li><em>Time to exit under freeze</em>: read off $t = N \mathbf{1}$ from the<br />
+<li><em>Time to exit under freeze</em>: read off $t = N \mathbf{1}$ from the
   fundamental matrix.</li>
 </ul>
-<p><strong>4. Run sensitivity.</strong> Vary each rate by $\pm 50\%$ and rank the impact on<br />
-the outcome you care about. The result tells you which lever to pull. For<br />
-the default headcount chain, Senior retention is the dominant lever for<br />
+<p><strong>4. Run sensitivity.</strong> Vary each rate by $\pm 50\%$ and rank the impact on
+the outcome you care about. The result tells you which lever to pull. For
+the default headcount chain, Senior retention is the dominant lever for
 team composition.</p>
-<p><strong>5. Wire decisions to thresholds.</strong> This is where the toolkit stops being<br />
-descriptive and becomes prescriptive. For each output you care about,<br />
+<p><strong>5. Wire decisions to thresholds.</strong> This is where the toolkit stops being
+descriptive and becomes prescriptive. For each output you care about,
 write down the threshold and the action triggered when it is crossed:</p>
 <table>
 <thead>
@@ -967,109 +967,109 @@ write down the threshold and the action triggered when it is crossed:</p>
 </tr>
 </tbody>
 </table>
-<p>The thresholds are decisions, not facts — they encode the planner's risk<br />
-tolerance. The model computes the probabilities; the thresholds define<br />
-what counts as "too low". Once they are written down, the model stops<br />
-producing reports and starts driving the operating cadence: each refresh<br />
-of HR data triggers a re-run that either confirms business-as-usual or<br />
+<p>The thresholds are decisions, not facts — they encode the planner's risk
+tolerance. The model computes the probabilities; the thresholds define
+what counts as "too low". Once they are written down, the model stops
+producing reports and starts driving the operating cadence: each refresh
+of HR data triggers a re-run that either confirms business-as-usual or
 fires a specific intervention.</p>
-<p>The whole process fits in a Jupyter notebook. The companion repository has<br />
-templates for each step. Once a planner has done it once, the marginal cost<br />
-of running another scenario is zero — the ROI on a one-time investment in<br />
+<p>The whole process fits in a Jupyter notebook. The companion repository has
+templates for each step. Once a planner has done it once, the marginal cost
+of running another scenario is zero — the ROI on a one-time investment in
 this apparatus is high.</p>
 <hr />
 <h2 id="limitations">Limitations</h2>
-<p>The model is deliberately simple; the boundaries below are where a real<br />
+<p>The model is deliberately simple; the boundaries below are where a real
 deployment must look before trusting the closed forms.</p>
-<p><strong>Memorylessness.</strong> The Markov property assumes attrition and promotion<br />
-depend only on the current level, not on tenure. Cohort effects — new<br />
-hires churning faster in their first six months — require expanding the<br />
+<p><strong>Memorylessness.</strong> The Markov property assumes attrition and promotion
+depend only on the current level, not on tenure. Cohort effects — new
+hires churning faster in their first six months — require expanding the
 state space (level × tenure bucket) at the cost of more rates to estimate.</p>
-<p><strong>Time-homogeneous rates.</strong> All rates are constant over the horizon. Real<br />
-rates drift with the labour market, compensation reviews, and<br />
-reorganisations. The framework accepts updated rates at any time — but<br />
-each update resets the transient analysis, and long-run statements assume<br />
+<p><strong>Time-homogeneous rates.</strong> All rates are constant over the horizon. Real
+rates drift with the labour market, compensation reviews, and
+reorganisations. The framework accepts updated rates at any time — but
+each update resets the transient analysis, and long-run statements assume
 the rates persist.</p>
-<p><strong>Decoupled size and composition.</strong> Team size (birth-death) and<br />
-career-level composition (DTMC) are modelled independently. As discussed<br />
-in <a href="#the-headcount-model">The Headcount Model</a>, this is accurate when<br />
-attrition is roughly homogeneous across levels and breaks under strongly<br />
-heterogeneous attrition, capacity-coupled hiring, or cohort effects — the<br />
+<p><strong>Decoupled size and composition.</strong> Team size (birth-death) and
+career-level composition (DTMC) are modelled independently. As discussed
+in <a href="#the-headcount-model">The Headcount Model</a>, this is accurate when
+attrition is roughly homogeneous across levels and breaks under strongly
+heterogeneous attrition, capacity-coupled hiring, or cohort effects — the
 bias for the default parameters is 1–3% on second moments.</p>
-<p><strong>Estimation risk.</strong> Transition rates estimated from 12–24 months of HR<br />
-data on a 50-person team carry substantial sampling error, which propagates<br />
-to every downstream quantity. The article treats rates as known;<br />
-quantifying rate uncertainty (e.g., via Bayesian updating of the rates<br />
+<p><strong>Estimation risk.</strong> Transition rates estimated from 12–24 months of HR
+data on a 50-person team carry substantial sampling error, which propagates
+to every downstream quantity. The article treats rates as known;
+quantifying rate uncertainty (e.g., via Bayesian updating of the rates
 themselves) is a natural extension.</p>
-<p><strong>Single, closed team.</strong> No transfers between teams, no re-hires, no<br />
-contractor pool. Networked workforce flows need a richer state space than<br />
+<p><strong>Single, closed team.</strong> No transfers between teams, no re-hires, no
+contractor pool. Networked workforce flows need a richer state space than
 the single chain used here.</p>
 <hr />
 <h2 id="conclusion">Conclusion</h2>
-<p>A headcount plan that names a single number is a lossy compression of the<br />
-random process underneath. The compression hides three pieces of useful<br />
-information: the probability of hitting the number, the expected time to<br />
-get there, and the steady state the system tends toward. Markov chain<br />
-theory recovers all three in closed form, and the recovery costs almost<br />
+<p>A headcount plan that names a single number is a lossy compression of the
+random process underneath. The compression hides three pieces of useful
+information: the probability of hitting the number, the expected time to
+get there, and the steady state the system tends toward. Markov chain
+theory recovers all three in closed form, and the recovery costs almost
 nothing once the apparatus is set up.</p>
-<p>The cost is up-front: defining the state space, estimating rates, choosing<br />
-between absorbing and recycling formulations. The pay-off is permanent. A<br />
-one-line update of the rates suffices to re-answer every question; a<br />
+<p>The cost is up-front: defining the state space, estimating rates, choosing
+between absorbing and recycling formulations. The pay-off is permanent. A
+one-line update of the rates suffices to re-answer every question; a
 notebook of scenarios runs in seconds.</p>
-<p>The deeper lesson is that "long run" is a verb, not a noun. The spectral<br />
-gap of the headcount chain is small — about 0.01 — meaning the long run<br />
-takes years, not quarters. Quarterly hiring plans cannot reach the<br />
-stationary distribution; they can only redirect the transient trajectory<br />
-toward it. Planners who treat the steady state as a destination will be<br />
+<p>The deeper lesson is that "long run" is a verb, not a noun. The spectral
+gap of the headcount chain is small — about 0.01 — meaning the long run
+takes years, not quarters. Quarterly hiring plans cannot reach the
+stationary distribution; they can only redirect the transient trajectory
+toward it. Planners who treat the steady state as a destination will be
 disappointed; planners who use it as a compass will be calibrated.</p>
-<p>This article is the natural complement to<br />
-<a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a>.<br />
-There, the total budget was simulated assuming a known headcount; here,<br />
-headcount itself was modelled as the random process it actually is.<br />
-Together, the two convert workforce planning from a series of educated<br />
-guesses into a probabilistic system that can be queried, perturbed, and<br />
-audited. The deterministic plan is one statistic among many. It is no<br />
+<p>This article is the natural complement to
+<a href="monte-carlo-budget.html">Why Your Budget Never Hits the Exact Number</a>.
+There, the total budget was simulated assuming a known headcount; here,
+headcount itself was modelled as the random process it actually is.
+Together, the two convert workforce planning from a series of educated
+guesses into a probabilistic system that can be queried, perturbed, and
+audited. The deterministic plan is one statistic among many. It is no
 longer the answer.</p>
 <h3 id="three-things-to-do-monday-morning">Three things to do Monday morning</h3>
-<p>If the apparatus described in this article is to land, it has to start<br />
+<p>If the apparatus described in this article is to land, it has to start
 small. Three concrete steps for the next planning cycle:</p>
 <ol>
-<li><strong>Estimate the rates.</strong> Pull the last 12 months of HR data and compute<br />
-   monthly transition fractions per career level. This is one<br />
-<code>groupby</code> away on most HRIS exports. The resulting transition matrix<br />
+<li><strong>Estimate the rates.</strong> Pull the last 12 months of HR data and compute
+   monthly transition fractions per career level. This is one
+   <code>groupby</code> away on most HRIS exports. The resulting transition matrix
    $P$ is the cost of entry; everything else is one Jupyter cell.</li>
-<li><strong>Solve $\pi P = \pi$ and compare to your aspiration.</strong> If the<br />
-   stationary composition disagrees with the team you say you want to<br />
-   build, the rates are the lever — not the next quarter's hiring plan.<br />
+<li><strong>Solve $\pi P = \pi$ and compare to your aspiration.</strong> If the
+   stationary composition disagrees with the team you say you want to
+   build, the rates are the lever — not the next quarter's hiring plan.
    This single number recasts the entire conversation.</li>
-<li><strong>Write down two thresholds.</strong> Pick the one risk you care about most<br />
-   ($P(n_{12} \geq \text{target}) < 60\%$, or Senior share below 35%, or<br />
-   layoff scenario entry), pick the action it triggers, and put it in the<br />
-   shared planning document. Future you will run the model on a cadence;<br />
+<li><strong>Write down two thresholds.</strong> Pick the one risk you care about most
+   ($P(n_{12} \geq \text{target}) < 60\%$, or Senior share below 35%, or
+   layoff scenario entry), pick the action it triggers, and put it in the
+   shared planning document. Future you will run the model on a cadence;
    today's you defines what "too low" means.</li>
 </ol>
-<p>If the three steps are in place by next Monday, the workforce plan is<br />
-already operating in a different regime — one where uncertainty is named,<br />
+<p>If the three steps are in place by next Monday, the workforce plan is
+already operating in a different regime — one where uncertainty is named,
 priced, and watched.</p>
 <hr />
 <h2 id="references">References</h2>
 <ul>
-<li>Bartholomew, D. J. (1982). <em>Stochastic Models for Social Processes</em>.<br />
+<li>Bartholomew, D. J. (1982). <em>Stochastic Models for Social Processes</em>.
   Wiley. <em>(workforce modelling — directly relevant)</em></li>
 <li>Grinstead, C. &amp; Snell, J. (1997). <em>Introduction to Probability</em>. AMS.</li>
-<li>Levin, D., Peres, Y. &amp; Wilmer, E. (2009). <em>Markov Chains and Mixing<br />
+<li>Levin, D., Peres, Y. &amp; Wilmer, E. (2009). <em>Markov Chains and Mixing
   Times</em>. AMS.</li>
 <li>Norris, J. R. (1997). <em>Markov Chains</em>. Cambridge University Press.</li>
-<li>Ross, S. M. (2014). <em>Introduction to Probability Models</em>. Academic<br />
+<li>Ross, S. M. (2014). <em>Introduction to Probability Models</em>. Academic
   Press, 11th ed.</li>
-<li>Taylor, H. M. &amp; Karlin, S. (1998). <em>An Introduction to Stochastic<br />
+<li>Taylor, H. M. &amp; Karlin, S. (1998). <em>An Introduction to Stochastic
   Modeling</em>. Academic Press, 3rd ed.</li>
 </ul>
 <hr />
-<p><em>All figures and numbers in this article are reproduced by versioned<br />
-scripts with fixed seed 2026 in the<br />
-<a href="https://github.com/brunoramosmartins/headcount-dynamics-article">companion repository</a>.<br />
-Run <code>pip install -e ".[dev]"</code> then <code>python scripts/run_all_experiments.py</code><br />
+<p><em>All figures and numbers in this article are reproduced by versioned
+scripts with fixed seed 2026 in the
+<a href="https://github.com/brunoramosmartins/headcount-dynamics-article">companion repository</a>.
+Run <code>pip install -e ".[dev]"</code> then <code>python scripts/run_all_experiments.py</code>
 to regenerate the full figure set.</em></p>
           
         </article>

--- a/posts/monte-carlo-budget.html
+++ b/posts/monte-carlo-budget.html
@@ -366,7 +366,7 @@
 </ul>
 <p>A point estimate gives you a number. A distribution gives you the <strong>policy</strong>: how much to reserve, when to escalate, and how confident to be at every step.</p>
 <h3 id="what-changes-with-a-distribution">What Changes With a Distribution</h3>
-<p>This article replaces the single number with a <strong>probability distribution</strong>. Using Monte Carlo simulation grounded in the Law of Large Numbers and the Central Limit Theorem, we transform "we expect to spend R$ 11.5M" into "we are 90% confident spending will fall between R$ 10.7M and R$ 12.4M, with a 3% probability of exceeding the ceiling."</p>
+<p>This article replaces the single number with a <strong>probability distribution</strong>. Using Monte Carlo simulation grounded in the Law of Large Numbers and the Central Limit Theorem, we transform "we expect to spend R\$ 11.5M" into "we are 90% confident spending will fall between R\$ 10.7M and R\$ 12.4M, with a 3% probability of exceeding the ceiling."</p>
 <blockquote>
 <p><strong>A budget is a distribution, not a number.</strong> This single shift changes how budgets are <em>approved</em>, not just how they are <em>calculated</em>. The output is no longer a target — it is a risk profile that a CFO can underwrite.</p>
 </blockquote>
@@ -378,7 +378,7 @@
 <p>$$
 \hat{X} = \sum_{k} (\text{quantity}_k \times \text{unit cost}_k) + \text{contingency}
 $$</p>
-<p>The result is a number — say, R$ 11.5 million. But this number is $E[X_{\text{total}}]$: the expected value of a random variable. It tells us the centre of the distribution. What it discards is everything else:</p>
+<p>The result is a number — say, R\$ 11.5 million. But this number is $E[X_{\text{total}}]$: the expected value of a random variable. It tells us the centre of the distribution. What it discards is everything else:</p>
 <ul>
 <li><strong>Variance:</strong> How spread out are the possible outcomes?</li>
 <li><strong>Skewness:</strong> Is the distribution symmetric, or could costs be pulled higher by a few extreme events?</li>
@@ -689,7 +689,7 @@ $$</p>
 <figure><img src="../figures/monte-carlo-budget/variance_reduction_comparison.png" alt="95% CI width versus N for naive Monte Carlo, antithetic variates, and control variates." loading="lazy"><figcaption>95% CI width versus N for naive Monte Carlo, antithetic variates, and control variates.</figcaption></figure>
 <h3 id="why-this-matters-beyond-the-math-compute-roi">Why This Matters Beyond the Math: Compute ROI</h3>
 <p>A 30× variance reduction sounds like a mathematical curiosity. It is a <strong>compute and response-time</strong> result.</p>
-<p>Suppose the naive simulation needs $N = 30{,}000$ runs to deliver a ±R$ 50K confidence interval. With control variates, the same precision lands at $N = 1{,}000$. Translating into engineering reality:</p>
+<p>Suppose the naive simulation needs $N = 30{,}000$ runs to deliver a ±R\$ 50K confidence interval. With control variates, the same precision lands at $N = 1{,}000$. Translating into engineering reality:</p>
 <table>
 <thead>
 <tr>
@@ -701,7 +701,7 @@ $$</p>
 </thead>
 <tbody>
 <tr>
-<td>Runs to ±R$ 50K CI</td>
+<td>Runs to ±R\$ 50K CI</td>
 <td>30,000</td>
 <td>1,000</td>
 <td>30× fewer scenarios</td>
@@ -810,7 +810,7 @@ $$</p>
 <h3 id="experiment-a-lln-convergence">Experiment A — LLN Convergence</h3>
 <p><strong>Claim.</strong> The sample mean converges to the analytical $E[X]$ as $N$ grows, with variance shrinking at rate $O(1/\sqrt{N})$.</p>
 <p><strong>Setup.</strong> 10 independent runs of LogNormal salary draws, $N$ from 1 to 10,000 each; absolute deviation $|\bar{X}_n - E[X]|$ tracked across runs, with the Chebyshev 95% band overlaid.</p>
-<p><strong>Result.</strong> At small $N$, runs spread widely; by $N = 5{,}000$, all 10 runs cluster within R$ 200 of the analytical mean. The empirical decay matches $\sigma/\sqrt{n}$ on a log-log plot.</p>
+<p><strong>Result.</strong> At small $N$, runs spread widely; by $N = 5{,}000$, all 10 runs cluster within R\$ 200 of the analytical mean. The empirical decay matches $\sigma/\sqrt{n}$ on a log-log plot.</p>
 <p><strong>Connection.</strong> The Weak Law proved in <a href="#the-law-of-large-numbers">The Law of Large Numbers</a>, observed at finite $N$ (the figure lives in that section).</p>
 <h3 id="experiment-b-clt-normality">Experiment B — CLT Normality</h3>
 <p><strong>Claim.</strong> The standardised sample mean of LogNormal draws converges in distribution to $N(0, 1)$ — right-skewed costs in, bell curve out.</p>
@@ -819,8 +819,8 @@ $$</p>
 <p><strong>Connection.</strong> The MGF proof in <a href="#the-central-limit-theorem">The Central Limit Theorem</a>, watched happening (the figure lives in that section).</p>
 <h3 id="experiment-c-full-budget-simulation">Experiment C — Full Budget Simulation</h3>
 <p><strong>Claim.</strong> Monte Carlo recovers the full distribution of $X_{\text{total}}$ — not just its mean — including the ceiling-breach probability no point estimate can produce.</p>
-<p><strong>Setup.</strong> $N = 50{,}000$ iterations of the IT headcount budget model with default parameters, seed 42; ceiling at R$ 12.5M; metrics: relative error of the MC mean vs analytical $E[X]$, 95% CI half-width, P5–P95 range, $P(X \gt \text{ceiling})$.</p>
-<p><strong>Result.</strong> MC mean within 0.1% of analytical. 95% CI half-width approximately R$ 4K. P5–P95 spans ~R$ 1.6M. The probability of exceeding R$ 12.5M is approximately 3%. The distribution is right-skewed.</p>
+<p><strong>Setup.</strong> $N = 50{,}000$ iterations of the IT headcount budget model with default parameters, seed 42; ceiling at R\$ 12.5M; metrics: relative error of the MC mean vs analytical $E[X]$, 95% CI half-width, P5–P95 range, $P(X \gt \text{ceiling})$.</p>
+<p><strong>Result.</strong> MC mean within 0.1% of analytical. 95% CI half-width approximately R\$ 4K. P5–P95 spans ~R\$ 1.6M. The probability of exceeding R\$ 12.5M is approximately 3%. The distribution is right-skewed.</p>
 <p><strong>Connection.</strong> Instantiates the full model of <a href="#budget-components-as-random-variables">Budget Components as Random Variables</a> and delivers the risk profile promised in <a href="#the-point-estimate-problem">The Point Estimate Problem</a>.</p>
 <figure><img src="../figures/monte-carlo-budget/budget_simulation.png" alt="Budget cost distribution (histogram and CDF) with mean, P5/P95, and the budget ceiling annotated." loading="lazy"><figcaption>Budget cost distribution (histogram and CDF) with mean, P5/P95, and the budget ceiling annotated.</figcaption></figure>
 <h3 id="experiment-d-variance-reduction">Experiment D — Variance Reduction</h3>
@@ -848,7 +848,7 @@ $$</p>
 <tbody>
 <tr>
 <td>Analytical $E[X]$</td>
-<td>R$ 11.55M</td>
+<td>R\$ 11.55M</td>
 </tr>
 <tr>
 <td>MC mean (N=50K)</td>
@@ -856,14 +856,14 @@ $$</p>
 </tr>
 <tr>
 <td>95% CI half-width (N=50K)</td>
-<td>~R$ 4K</td>
+<td>~R\$ 4K</td>
 </tr>
 <tr>
 <td>P5–P95 range</td>
-<td>~R$ 1.6M</td>
+<td>~R\$ 1.6M</td>
 </tr>
 <tr>
-<td>P(X exceeds R$ 12.5M)</td>
+<td>P(X exceeds R\$ 12.5M)</td>
 <td>~3%</td>
 </tr>
 <tr>
@@ -968,11 +968,11 @@ $$</p>
 <p>The single highest-leverage moment in this whole article is the language a budget owner uses in front of leadership. Print this side-by-side comparison and stick it on the wall.</p>
 <blockquote>
 <p><strong>Before — point estimate:</strong></p>
-<p><em>"The budget for next year is R$ 11.55M."</em></p>
+<p><em>"The budget for next year is R\$ 11.55M."</em></p>
 <p>A target. No risk attached. Every variance reads as a miss.</p>
 <p><strong>After — distribution + policy:</strong></p>
-<p><em>"We are 95% confident the cost will fall between R$ 10.7M and R$ 12.4M, with a mean of R$ 11.55M.</em></p>
-<p><em>We propose to reserve R$ 12.0M as the planned budget (P90), with an additional R$ 500K of risk capital available if needed (P99). The probability of exceeding R$ 12.5M is approximately 3%. The primary driver of uncertainty is [dominant component] — investing in better salary forecasts will tighten the range more than any other action."</em></p>
+<p><em>"We are 95% confident the cost will fall between R\$ 10.7M and R\$ 12.4M, with a mean of R\$ 11.55M.</em></p>
+<p><em>We propose to reserve R\$ 12.0M as the planned budget (P90), with an additional R\$ 500K of risk capital available if needed (P99). The probability of exceeding R\$ 12.5M is approximately 3%. The primary driver of uncertainty is [dominant component] — investing in better salary forecasts will tighten the range more than any other action."</em></p>
 <p>A risk profile leadership can underwrite. Variances read against the <em>interval</em>, not the mean.</p>
 </blockquote>
 <p>The "After" script is not longer because it is more verbose — it is longer because it carries the <strong>information the spreadsheet had to throw away</strong>. Practise saying it out loud.</p>

--- a/posts/probabilistic-cost-modelling.html
+++ b/posts/probabilistic-cost-modelling.html
@@ -568,9 +568,9 @@
 <h3 id="choosing-k">Choosing K</h3>
 <p>We use BIC to select the number of components: fit GMMs with $K = 1, 2, 3, \ldots$ and choose the $K$ that minimizes BIC.</p>
 <h3 id="the-budget-cost-of-ignoring-bimodality">The Budget Cost of Ignoring Bimodality</h3>
-<p>In <a href="#experiment-d-mixture-detection">Experiment D</a>, ignoring bimodality and forcing a single Normal on a 60% junior / 40% senior mixture:<br />
-- Inflates the estimated standard deviation by ~40%<br />
-- Distorts VaR(95%) by R\$ 1,500–2,500 per employee<br />
+<p>In <a href="#experiment-d-mixture-detection">Experiment D</a>, ignoring bimodality and forcing a single Normal on a 60% junior / 40% senior mixture:
+- Inflates the estimated standard deviation by ~40%
+- Distorts VaR(95%) by R\$ 1,500–2,500 per employee
 - For a 50-person team, this is R\$ 75K–125K of misallocated reserve</p>
 <p><strong>Mental hook:</strong> <em>In bimodal distributions, the average represents no one.</em></p>
 <figure><img src="../figures/probabilistic-cost-modelling/mixture_detection.png" alt="Mixture detection: GMM identifies bimodal structure" loading="lazy"><figcaption>Mixture detection: GMM identifies bimodal structure</figcaption></figure>
@@ -586,8 +586,8 @@
 <p>For $X \sim \text{Pareto}(\alpha, x_m)$:</p>
 <p>$$P(X > x) = \left(\frac{x_m}{x}\right)^\alpha$$</p>
 <p>This decays <strong>polynomially</strong>. Compare with the Normal, which decays as $e^{-x^2/2}$ (super-exponentially).</p>
-<p><strong>Tail thinning ratio:</strong><br />
-- Pareto: $P(X > 2c) / P(X > c) = 2^{-\alpha}$ (constant!)<br />
+<p><strong>Tail thinning ratio:</strong>
+- Pareto: $P(X > 2c) / P(X > c) = 2^{-\alpha}$ (constant!)
 - Normal: the same ratio decays exponentially</p>
 <blockquote>
 <p><strong>Mental hook.</strong> <em>Tail risk is where budgets fail, not where averages live.</em> In a Normal world, doubling the threshold makes the event astronomically rarer. In a Pareto world, doubling the threshold reduces the probability by a fixed factor — independent of where you started.</p>
@@ -686,23 +686,23 @@
 <h2 id="a-practical-framework">A Practical Framework</h2>
 <p>The theory and experiments above point to a concrete decision procedure. This section condenses everything into a five-step workflow that any analyst can apply to their own data.</p>
 <h3 id="decision-tree-for-distribution-selection">Decision Tree for Distribution Selection</h3>
-<p><strong>Step 1: Visualize</strong><br />
-- Histogram + Q-Q plot<br />
+<p><strong>Step 1: Visualize</strong>
+- Histogram + Q-Q plot
 - Is the data skewed? Multimodal? Are there extreme values?</p>
-<p><strong>Step 2: Fit candidates</strong><br />
-- Use MLE to fit 3-5 distribution families<br />
+<p><strong>Step 2: Fit candidates</strong>
+- Use MLE to fit 3-5 distribution families
 - Check convergence and parameter reasonableness</p>
-<p><strong>Step 3: Compare</strong><br />
-- Compute AIC and BIC for all candidates<br />
-- Compute Akaike weights — is there a clear winner?<br />
+<p><strong>Step 3: Compare</strong>
+- Compute AIC and BIC for all candidates
+- Compute Akaike weights — is there a clear winner?
 - Use AIC for prediction, BIC for identifying the "true" model</p>
-<p><strong>Step 4: Validate</strong><br />
-- Goodness-of-fit test (Anderson-Darling for tails)<br />
-- Q-Q plot of the winning model<br />
+<p><strong>Step 4: Validate</strong>
+- Goodness-of-fit test (Anderson-Darling for tails)
+- Q-Q plot of the winning model
 - Does the winning model actually fit well?</p>
-<p><strong>Step 5: Quantify impact</strong><br />
-- Compute VaR and ES under the selected model<br />
-- Compare with what Normal would have predicted<br />
+<p><strong>Step 5: Quantify impact</strong>
+- Compute VaR and ES under the selected model
+- Compare with what Normal would have predicted
 - Translate the difference into R\$ of budget reserve</p>
 <h3 id="common-pitfalls">Common Pitfalls</h3>
 <ol>


### PR DESCRIPTION
- Drop the nl2br Markdown extension: hard-wrapped prose was rendering with a forced line break on every source newline (headcount and bayesian were badly affected). Verified paragraph counts and structure are unchanged — only <br> tags are removed.
- Escape the 22 currency dollar signs in the Monte Carlo article (R$) so MathJax renders them literally instead of opening a spurious math span.
- WRITING-GUIDE: correct the currency rule to always escape $ (this was the source of the bug).