### PR TITLE
Reading experience: fix line breaks, currency, add navigator + progress bar

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -691,3 +691,70 @@
   }
 
 }
+
+/* ============================================================
+   Reading experience — progress bar + left "All writing" panel
+   Shared by article_template.html and til_template.html
+   ============================================================ */
+
+/* Thin progress bar that fills as the reader scrolls (JS sets width) */
+.reading-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 3px;
+  width: 0;
+  background-color: var(--color-accent);
+  z-index: 200;            /* above the fixed header (z-index 100) */
+  transition: width 120ms linear;
+}
+
+/* Left-hand navigator listing all writing, newest first */
+.article-nav { display: none; }   /* shown only on wide viewports (template media query) */
+
+.article-nav__inner {
+  position: sticky;
+  top: calc(var(--header-height) + var(--space-6));
+  max-height: calc(100vh - var(--header-height) - var(--space-12));
+  overflow-y: auto;
+  padding-right: var(--space-5);
+  border-right: 1px solid var(--color-border);
+}
+
+.article-nav__title {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-4);
+}
+
+.article-nav__list { list-style: none; padding: 0; margin: 0; }
+.article-nav__item { margin-bottom: var(--space-4); }
+
+.article-nav__link {
+  display: block;
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  padding-left: var(--space-3);
+  border-left: 2px solid transparent;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+.article-nav__link:hover { color: var(--color-text-primary); }
+.article-nav__link.active {
+  color: var(--color-accent);
+  border-left-color: var(--color-accent);
+  font-weight: var(--weight-medium);
+}
+
+.article-nav__meta {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  margin-top: 2px;
+  letter-spacing: 0.04em;
+}

--- a/assets/js/articleNav.js
+++ b/assets/js/articleNav.js
@@ -1,0 +1,63 @@
+/**
+ * articleNav.js — left-hand "All writing" panel for article and TIL pages.
+ *
+ * Fetches data/articles.json, lists every piece newest-first, links to each,
+ * and highlights the current page. The panel is position:sticky (set in CSS),
+ * so it stays put while the article scrolls — same behaviour as On This Page.
+ *
+ * Plain script (no modules), loaded with `defer`.
+ */
+(function () {
+  'use strict';
+
+  var listEl = document.getElementById('article-nav-list');
+  var navEl = document.querySelector('.article-nav');
+  if (!listEl || !navEl) return;
+
+  var MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+  function formatDate(d) {
+    if (!d) return '';
+    var p = d.split('-');
+    var m = MONTHS[parseInt(p[1], 10) - 1] || '';
+    return (m + ' ' + p[0]).trim();
+  }
+
+  var here = location.pathname; // e.g. /posts/foo.html or /til/bar.html
+
+  fetch('../data/articles.json')
+    .then(function (r) { return r.json(); })
+    .then(function (items) {
+      items.sort(function (a, b) {
+        return (b.date || '').localeCompare(a.date || '');
+      });
+
+      var frag = document.createDocumentFragment();
+      items.forEach(function (it) {
+        var li = document.createElement('li');
+        li.className = 'article-nav__item';
+
+        var a = document.createElement('a');
+        a.className = 'article-nav__link';
+        a.href = '..' + it.url;               // /posts/x.html -> ../posts/x.html
+        a.appendChild(document.createTextNode(it.title));
+
+        if (here.slice(-it.url.length) === it.url) {
+          a.classList.add('active');
+          a.setAttribute('aria-current', 'page');
+        }
+
+        var meta = document.createElement('span');
+        meta.className = 'article-nav__meta';
+        meta.textContent = formatDate(it.date) +
+          (it.category === 'til' ? ' · TIL' : '');
+        a.appendChild(meta);
+
+        li.appendChild(a);
+        frag.appendChild(li);
+      });
+      listEl.appendChild(frag);
+    })
+    .catch(function () { navEl.hidden = true; });
+})();

--- a/assets/js/readingProgress.js
+++ b/assets/js/readingProgress.js
@@ -1,0 +1,35 @@
+/**
+ * readingProgress.js — thin progress bar that fills as the reader scrolls.
+ *
+ * Plain script (no modules), loaded with `defer`. Reports whole-page scroll
+ * progress, which maps directly to "how much of the article is left".
+ */
+(function () {
+  'use strict';
+
+  var bar = document.getElementById('reading-progress');
+  if (!bar) return;
+
+  function update() {
+    var doc = document.documentElement;
+    var scrollable = doc.scrollHeight - doc.clientHeight;
+    var pct = scrollable > 0 ? window.scrollY / scrollable : 0;
+    if (pct < 0) pct = 0;
+    if (pct > 1) pct = 1;
+    bar.style.width = (pct * 100) + '%';
+  }
+
+  var ticking = false;
+  function onScroll() {
+    if (ticking) return;
+    ticking = true;
+    setTimeout(function () {
+      update();
+      ticking = false;
+    }, 50);
+  }
+
+  document.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('resize', onScroll, { passive: true });
+  update();
+})();

--- a/posts/bayesian-fyf.html
+++ b/posts/bayesian-fyf.html
@@ -161,20 +161,30 @@
     h3:hover .heading-anchor { opacity: 1; }
     .heading-anchor:hover { color: var(--color-accent); }
 
-    /* === Two-column layout with "On this page" panel === */
+    /* === Reading layout: prose + On This Page (+ left navigator) === */
     .article-layout { display: block; }
     .article-toc { display: none; }
 
+    /* Medium screens: 2 columns (prose + On This Page) */
     @media (min-width: 1200px) {
       .article-layout {
         display: grid;
-        grid-template-columns: minmax(0, var(--container-max)) 220px;
-        gap: var(--space-16);
+        grid-template-columns: minmax(0, var(--container-max)) 210px;
+        gap: var(--space-12);
         justify-content: center;
-        /* grid items stretch by default: the aside spans the full article
-           height, giving the sticky inner panel room to travel */
+        /* grid items stretch by default: asides span the full article
+           height, giving the sticky inner panels room to travel */
       }
       .article-toc { display: block; }
+    }
+
+    /* Wide screens: 3 columns (navigator + prose + On This Page) */
+    @media (min-width: 1440px) {
+      .site-main .container--wide { max-width: 1360px; }
+      .article-layout {
+        grid-template-columns: 210px minmax(0, var(--container-max)) 210px;
+      }
+      .article-nav { display: block; }
     }
 
     .article-toc__inner {
@@ -222,6 +232,7 @@
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
 
   <!-- =========================================================
        HEADER
@@ -267,6 +278,14 @@
       </header>
 
       <div class="article-layout">
+
+        <!-- All writing — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All writing">
+          <nav class="article-nav__inner">
+            <p class="article-nav__title">All writing</p>
+            <ul class="article-nav__list" id="article-nav-list"></ul>
+          </nav>
+        </aside>
 
         <!-- Article Body — injected by build_blog.py -->
         <article class="article-prose" aria-label="Article content">
@@ -1202,6 +1221,10 @@ documented and unit-tested.</em></p>
   <script src="../assets/js/navigation.js" defer></script>
   <!-- On This Page panel + heading anchors + scroll spy -->
   <script src="../assets/js/articleToc.js" defer></script>
+  <!-- Left "All writing" navigator -->
+  <script src="../assets/js/articleNav.js" defer></script>
+  <!-- Reading progress bar -->
+  <script src="../assets/js/readingProgress.js" defer></script>
 
 </body>
 </html>

--- a/posts/headcount-dynamics.html
+++ b/posts/headcount-dynamics.html
@@ -161,20 +161,30 @@
     h3:hover .heading-anchor { opacity: 1; }
     .heading-anchor:hover { color: var(--color-accent); }
 
-    /* === Two-column layout with "On this page" panel === */
+    /* === Reading layout: prose + On This Page (+ left navigator) === */
     .article-layout { display: block; }
     .article-toc { display: none; }
 
+    /* Medium screens: 2 columns (prose + On This Page) */
     @media (min-width: 1200px) {
       .article-layout {
         display: grid;
-        grid-template-columns: minmax(0, var(--container-max)) 220px;
-        gap: var(--space-16);
+        grid-template-columns: minmax(0, var(--container-max)) 210px;
+        gap: var(--space-12);
         justify-content: center;
-        /* grid items stretch by default: the aside spans the full article
-           height, giving the sticky inner panel room to travel */
+        /* grid items stretch by default: asides span the full article
+           height, giving the sticky inner panels room to travel */
       }
       .article-toc { display: block; }
+    }
+
+    /* Wide screens: 3 columns (navigator + prose + On This Page) */
+    @media (min-width: 1440px) {
+      .site-main .container--wide { max-width: 1360px; }
+      .article-layout {
+        grid-template-columns: 210px minmax(0, var(--container-max)) 210px;
+      }
+      .article-nav { display: block; }
     }
 
     .article-toc__inner {
@@ -222,6 +232,7 @@
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
 
   <!-- =========================================================
        HEADER
@@ -267,6 +278,14 @@
       </header>
 
       <div class="article-layout">
+
+        <!-- All writing — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All writing">
+          <nav class="article-nav__inner">
+            <p class="article-nav__title">All writing</p>
+            <ul class="article-nav__list" id="article-nav-list"></ul>
+          </nav>
+        </aside>
 
         <!-- Article Body — injected by build_blog.py -->
         <article class="article-prose" aria-label="Article content">
@@ -1105,6 +1124,10 @@ to regenerate the full figure set.</em></p>
   <script src="../assets/js/navigation.js" defer></script>
   <!-- On This Page panel + heading anchors + scroll spy -->
   <script src="../assets/js/articleToc.js" defer></script>
+  <!-- Left "All writing" navigator -->
+  <script src="../assets/js/articleNav.js" defer></script>
+  <!-- Reading progress bar -->
+  <script src="../assets/js/readingProgress.js" defer></script>
 
 </body>
 </html>

--- a/posts/krippendorff-alpha.html
+++ b/posts/krippendorff-alpha.html
@@ -161,20 +161,30 @@
     h3:hover .heading-anchor { opacity: 1; }
     .heading-anchor:hover { color: var(--color-accent); }
 
-    /* === Two-column layout with "On this page" panel === */
+    /* === Reading layout: prose + On This Page (+ left navigator) === */
     .article-layout { display: block; }
     .article-toc { display: none; }
 
+    /* Medium screens: 2 columns (prose + On This Page) */
     @media (min-width: 1200px) {
       .article-layout {
         display: grid;
-        grid-template-columns: minmax(0, var(--container-max)) 220px;
-        gap: var(--space-16);
+        grid-template-columns: minmax(0, var(--container-max)) 210px;
+        gap: var(--space-12);
         justify-content: center;
-        /* grid items stretch by default: the aside spans the full article
-           height, giving the sticky inner panel room to travel */
+        /* grid items stretch by default: asides span the full article
+           height, giving the sticky inner panels room to travel */
       }
       .article-toc { display: block; }
+    }
+
+    /* Wide screens: 3 columns (navigator + prose + On This Page) */
+    @media (min-width: 1440px) {
+      .site-main .container--wide { max-width: 1360px; }
+      .article-layout {
+        grid-template-columns: 210px minmax(0, var(--container-max)) 210px;
+      }
+      .article-nav { display: block; }
     }
 
     .article-toc__inner {
@@ -222,6 +232,7 @@
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
 
   <!-- =========================================================
        HEADER
@@ -267,6 +278,14 @@
       </header>
 
       <div class="article-layout">
+
+        <!-- All writing — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All writing">
+          <nav class="article-nav__inner">
+            <p class="article-nav__title">All writing</p>
+            <ul class="article-nav__list" id="article-nav-list"></ul>
+          </nav>
+        </aside>
 
         <!-- Article Body — injected by build_blog.py -->
         <article class="article-prose" aria-label="Article content">
@@ -724,6 +743,10 @@ $$</p>
   <script src="../assets/js/navigation.js" defer></script>
   <!-- On This Page panel + heading anchors + scroll spy -->
   <script src="../assets/js/articleToc.js" defer></script>
+  <!-- Left "All writing" navigator -->
+  <script src="../assets/js/articleNav.js" defer></script>
+  <!-- Reading progress bar -->
+  <script src="../assets/js/readingProgress.js" defer></script>
 
 </body>
 </html>

--- a/posts/monte-carlo-budget.html
+++ b/posts/monte-carlo-budget.html
@@ -161,20 +161,30 @@
     h3:hover .heading-anchor { opacity: 1; }
     .heading-anchor:hover { color: var(--color-accent); }
 
-    /* === Two-column layout with "On this page" panel === */
+    /* === Reading layout: prose + On This Page (+ left navigator) === */
     .article-layout { display: block; }
     .article-toc { display: none; }
 
+    /* Medium screens: 2 columns (prose + On This Page) */
     @media (min-width: 1200px) {
       .article-layout {
         display: grid;
-        grid-template-columns: minmax(0, var(--container-max)) 220px;
-        gap: var(--space-16);
+        grid-template-columns: minmax(0, var(--container-max)) 210px;
+        gap: var(--space-12);
         justify-content: center;
-        /* grid items stretch by default: the aside spans the full article
-           height, giving the sticky inner panel room to travel */
+        /* grid items stretch by default: asides span the full article
+           height, giving the sticky inner panels room to travel */
       }
       .article-toc { display: block; }
+    }
+
+    /* Wide screens: 3 columns (navigator + prose + On This Page) */
+    @media (min-width: 1440px) {
+      .site-main .container--wide { max-width: 1360px; }
+      .article-layout {
+        grid-template-columns: 210px minmax(0, var(--container-max)) 210px;
+      }
+      .article-nav { display: block; }
     }
 
     .article-toc__inner {
@@ -222,6 +232,7 @@
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
 
   <!-- =========================================================
        HEADER
@@ -267,6 +278,14 @@
       </header>
 
       <div class="article-layout">
+
+        <!-- All writing — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All writing">
+          <nav class="article-nav__inner">
+            <p class="article-nav__title">All writing</p>
+            <ul class="article-nav__list" id="article-nav-list"></ul>
+          </nav>
+        </aside>
 
         <!-- Article Body — injected by build_blog.py -->
         <article class="article-prose" aria-label="Article content">
@@ -1109,6 +1128,10 @@ $$</p>
   <script src="../assets/js/navigation.js" defer></script>
   <!-- On This Page panel + heading anchors + scroll spy -->
   <script src="../assets/js/articleToc.js" defer></script>
+  <!-- Left "All writing" navigator -->
+  <script src="../assets/js/articleNav.js" defer></script>
+  <!-- Reading progress bar -->
+  <script src="../assets/js/readingProgress.js" defer></script>
 
 </body>
 </html>

--- a/posts/not-all-errors-cost-the-same.html
+++ b/posts/not-all-errors-cost-the-same.html
@@ -161,20 +161,30 @@
     h3:hover .heading-anchor { opacity: 1; }
     .heading-anchor:hover { color: var(--color-accent); }
 
-    /* === Two-column layout with "On this page" panel === */
+    /* === Reading layout: prose + On This Page (+ left navigator) === */
     .article-layout { display: block; }
     .article-toc { display: none; }
 
+    /* Medium screens: 2 columns (prose + On This Page) */
     @media (min-width: 1200px) {
       .article-layout {
         display: grid;
-        grid-template-columns: minmax(0, var(--container-max)) 220px;
-        gap: var(--space-16);
+        grid-template-columns: minmax(0, var(--container-max)) 210px;
+        gap: var(--space-12);
         justify-content: center;
-        /* grid items stretch by default: the aside spans the full article
-           height, giving the sticky inner panel room to travel */
+        /* grid items stretch by default: asides span the full article
+           height, giving the sticky inner panels room to travel */
       }
       .article-toc { display: block; }
+    }
+
+    /* Wide screens: 3 columns (navigator + prose + On This Page) */
+    @media (min-width: 1440px) {
+      .site-main .container--wide { max-width: 1360px; }
+      .article-layout {
+        grid-template-columns: 210px minmax(0, var(--container-max)) 210px;
+      }
+      .article-nav { display: block; }
     }
 
     .article-toc__inner {
@@ -222,6 +232,7 @@
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
 
   <!-- =========================================================
        HEADER
@@ -267,6 +278,14 @@
       </header>
 
       <div class="article-layout">
+
+        <!-- All writing — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All writing">
+          <nav class="article-nav__inner">
+            <p class="article-nav__title">All writing</p>
+            <ul class="article-nav__list" id="article-nav-list"></ul>
+          </nav>
+        </aside>
 
         <!-- Article Body — injected by build_blog.py -->
         <article class="article-prose" aria-label="Article content">
@@ -662,6 +681,10 @@
   <script src="../assets/js/navigation.js" defer></script>
   <!-- On This Page panel + heading anchors + scroll spy -->
   <script src="../assets/js/articleToc.js" defer></script>
+  <!-- Left "All writing" navigator -->
+  <script src="../assets/js/articleNav.js" defer></script>
+  <!-- Reading progress bar -->
+  <script src="../assets/js/readingProgress.js" defer></script>
 
 </body>
 </html>

--- a/posts/probabilistic-cost-modelling.html
+++ b/posts/probabilistic-cost-modelling.html
@@ -161,20 +161,30 @@
     h3:hover .heading-anchor { opacity: 1; }
     .heading-anchor:hover { color: var(--color-accent); }
 
-    /* === Two-column layout with "On this page" panel === */
+    /* === Reading layout: prose + On This Page (+ left navigator) === */
     .article-layout { display: block; }
     .article-toc { display: none; }
 
+    /* Medium screens: 2 columns (prose + On This Page) */
     @media (min-width: 1200px) {
       .article-layout {
         display: grid;
-        grid-template-columns: minmax(0, var(--container-max)) 220px;
-        gap: var(--space-16);
+        grid-template-columns: minmax(0, var(--container-max)) 210px;
+        gap: var(--space-12);
         justify-content: center;
-        /* grid items stretch by default: the aside spans the full article
-           height, giving the sticky inner panel room to travel */
+        /* grid items stretch by default: asides span the full article
+           height, giving the sticky inner panels room to travel */
       }
       .article-toc { display: block; }
+    }
+
+    /* Wide screens: 3 columns (navigator + prose + On This Page) */
+    @media (min-width: 1440px) {
+      .site-main .container--wide { max-width: 1360px; }
+      .article-layout {
+        grid-template-columns: 210px minmax(0, var(--container-max)) 210px;
+      }
+      .article-nav { display: block; }
     }
 
     .article-toc__inner {
@@ -222,6 +232,7 @@
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
 
   <!-- =========================================================
        HEADER
@@ -267,6 +278,14 @@
       </header>
 
       <div class="article-layout">
+
+        <!-- All writing — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All writing">
+          <nav class="article-nav__inner">
+            <p class="article-nav__title">All writing</p>
+            <ul class="article-nav__list" id="article-nav-list"></ul>
+          </nav>
+        </aside>
 
         <!-- Article Body — injected by build_blog.py -->
         <article class="article-prose" aria-label="Article content">
@@ -794,6 +813,10 @@
   <script src="../assets/js/navigation.js" defer></script>
   <!-- On This Page panel + heading anchors + scroll spy -->
   <script src="../assets/js/articleToc.js" defer></script>
+  <!-- Left "All writing" navigator -->
+  <script src="../assets/js/articleNav.js" defer></script>
+  <!-- Reading progress bar -->
+  <script src="../assets/js/readingProgress.js" defer></script>
 
 </body>
 </html>

--- a/templates/article_template.html
+++ b/templates/article_template.html
@@ -161,20 +161,30 @@
     h3:hover .heading-anchor { opacity: 1; }
     .heading-anchor:hover { color: var(--color-accent); }
 
-    /* === Two-column layout with "On this page" panel === */
+    /* === Reading layout: prose + On This Page (+ left navigator) === */
     .article-layout { display: block; }
     .article-toc { display: none; }
 
+    /* Medium screens: 2 columns (prose + On This Page) */
     @media (min-width: 1200px) {
       .article-layout {
         display: grid;
-        grid-template-columns: minmax(0, var(--container-max)) 220px;
-        gap: var(--space-16);
+        grid-template-columns: minmax(0, var(--container-max)) 210px;
+        gap: var(--space-12);
         justify-content: center;
-        /* grid items stretch by default: the aside spans the full article
-           height, giving the sticky inner panel room to travel */
+        /* grid items stretch by default: asides span the full article
+           height, giving the sticky inner panels room to travel */
       }
       .article-toc { display: block; }
+    }
+
+    /* Wide screens: 3 columns (navigator + prose + On This Page) */
+    @media (min-width: 1440px) {
+      .site-main .container--wide { max-width: 1360px; }
+      .article-layout {
+        grid-template-columns: 210px minmax(0, var(--container-max)) 210px;
+      }
+      .article-nav { display: block; }
     }
 
     .article-toc__inner {
@@ -222,6 +232,7 @@
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
 
   <!-- =========================================================
        HEADER
@@ -268,6 +279,14 @@
 
       <div class="article-layout">
 
+        <!-- All writing — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All writing">
+          <nav class="article-nav__inner">
+            <p class="article-nav__title">All writing</p>
+            <ul class="article-nav__list" id="article-nav-list"></ul>
+          </nav>
+        </aside>
+
         <!-- Article Body — injected by build_blog.py -->
         <article class="article-prose" aria-label="Article content">
           {{article_content}}
@@ -305,6 +324,10 @@
   <script src="../assets/js/navigation.js" defer></script>
   <!-- On This Page panel + heading anchors + scroll spy -->
   <script src="../assets/js/articleToc.js" defer></script>
+  <!-- Left "All writing" navigator -->
+  <script src="../assets/js/articleNav.js" defer></script>
+  <!-- Reading progress bar -->
+  <script src="../assets/js/readingProgress.js" defer></script>
 
 </body>
 </html>

--- a/templates/til_template.html
+++ b/templates/til_template.html
@@ -128,10 +128,26 @@
       color: var(--color-text-muted);
       letter-spacing: 0.06em;
     }
+
+    /* === Reading layout: left navigator + content === */
+    .til-layout { display: block; }
+
+    @media (min-width: 1440px) {
+      .site-main .container--wide { max-width: 1360px; }
+      .til-layout {
+        display: grid;
+        grid-template-columns: 210px minmax(0, var(--container-max));
+        gap: var(--space-12);
+        justify-content: center;
+      }
+      .article-nav { display: block; }
+      /* header and prose already max-width 780 + auto margins; fill the column */
+    }
   </style>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
 
   <header class="site-header" role="banner">
     <div class="container container--wide">
@@ -152,24 +168,36 @@
 
   <main class="site-main" id="main-content">
     <div class="container container--wide">
+      <div class="til-layout">
 
-      <header class="til-header">
-        <a href="../til.html" class="til-header__back">← TIL</a>
-        <p class="til-header__kicker">Today I Learned</p>
-        <h1 class="til-header__title">{{article_title}}</h1>
-        <div class="til-header__meta">
-          <time class="til-header__date" datetime="{{article_date_iso}}">{{article_date}}</time>
-          <div class="tags">
-            {{article_tags}}
-          </div>
+        <!-- All writing — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All writing">
+          <nav class="article-nav__inner">
+            <p class="article-nav__title">All writing</p>
+            <ul class="article-nav__list" id="article-nav-list"></ul>
+          </nav>
+        </aside>
+
+        <div class="til-main">
+          <header class="til-header">
+            <a href="../til.html" class="til-header__back">← TIL</a>
+            <p class="til-header__kicker">Today I Learned</p>
+            <h1 class="til-header__title">{{article_title}}</h1>
+            <div class="til-header__meta">
+              <time class="til-header__date" datetime="{{article_date_iso}}">{{article_date}}</time>
+              <div class="tags">
+                {{article_tags}}
+              </div>
+            </div>
+          </header>
+
+          <article class="til-prose" aria-label="TIL content">
+            {{article_content}}
+            {{cross_link_box}}
+          </article>
         </div>
-      </header>
 
-      <article class="til-prose" aria-label="TIL content">
-        {{article_content}}
-        {{cross_link_box}}
-      </article>
-
+      </div>
     </div>
   </main>
 
@@ -185,6 +213,10 @@
   </footer>
 
   <script src="../assets/js/navigation.js" defer></script>
+  <!-- Left "All writing" navigator -->
+  <script src="../assets/js/articleNav.js" defer></script>
+  <!-- Reading progress bar -->
+  <script src="../assets/js/readingProgress.js" defer></script>
 
 </body>
 </html>

--- a/til/benfords-law.html
+++ b/til/benfords-law.html
@@ -128,10 +128,26 @@
       color: var(--color-text-muted);
       letter-spacing: 0.06em;
     }
+
+    /* === Reading layout: left navigator + content === */
+    .til-layout { display: block; }
+
+    @media (min-width: 1440px) {
+      .site-main .container--wide { max-width: 1360px; }
+      .til-layout {
+        display: grid;
+        grid-template-columns: 210px minmax(0, var(--container-max));
+        gap: var(--space-12);
+        justify-content: center;
+      }
+      .article-nav { display: block; }
+      /* header and prose already max-width 780 + auto margins; fill the column */
+    }
   </style>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
 
   <header class="site-header" role="banner">
     <div class="container container--wide">
@@ -152,21 +168,31 @@
 
   <main class="site-main" id="main-content">
     <div class="container container--wide">
+      <div class="til-layout">
 
-      <header class="til-header">
-        <a href="../til.html" class="til-header__back">← TIL</a>
-        <p class="til-header__kicker">Today I Learned</p>
-        <h1 class="til-header__title">Benford's Law: two derivations, four tests, one fraud detector</h1>
-        <div class="til-header__meta">
-          <time class="til-header__date" datetime="2026-05-03">May 2026</time>
-          <div class="tags">
-            <span class="tag" data-category="til">til</span><span class="tag">statistics</span><span class="tag">fraud-detection</span><span class="tag">mathematics</span><span class="tag">audit</span>
-          </div>
-        </div>
-      </header>
+        <!-- All writing — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All writing">
+          <nav class="article-nav__inner">
+            <p class="article-nav__title">All writing</p>
+            <ul class="article-nav__list" id="article-nav-list"></ul>
+          </nav>
+        </aside>
 
-      <article class="til-prose" aria-label="TIL content">
-        <h1 id="benfords-law-two-derivations-four-tests-one-fraud-detector">Benford's Law: two derivations, four tests, one fraud detector</h1>
+        <div class="til-main">
+          <header class="til-header">
+            <a href="../til.html" class="til-header__back">← TIL</a>
+            <p class="til-header__kicker">Today I Learned</p>
+            <h1 class="til-header__title">Benford's Law: two derivations, four tests, one fraud detector</h1>
+            <div class="til-header__meta">
+              <time class="til-header__date" datetime="2026-05-03">May 2026</time>
+              <div class="tags">
+                <span class="tag" data-category="til">til</span><span class="tag">statistics</span><span class="tag">fraud-detection</span><span class="tag">mathematics</span><span class="tag">audit</span>
+              </div>
+            </div>
+          </header>
+
+          <article class="til-prose" aria-label="TIL content">
+            <h1 id="benfords-law-two-derivations-four-tests-one-fraud-detector">Benford's Law: two derivations, four tests, one fraud detector</h1>
 <blockquote>
 <p>The first digit of "natural" numerical data is not uniform but logarithmic: $P(d) = \log_{10}(1 + 1/d)$, so a leading 1 occurs about 30% of the time and a leading 9 less than 5%. This TIL gives two independent rigorous derivations, four conformity tests, and an end-to-end fraud-detection demo.</p>
 </blockquote>
@@ -363,9 +389,11 @@ $$</p>
 <li><strong>Berger, A. &amp; Hill, T. P.</strong> (2015). <em>An Introduction to Benford's Law</em>. Princeton University Press.</li>
 <li><strong>Rauch, B., Göttsche, M., Brähler, G. &amp; Engel, S.</strong> (2011). Fact and fiction in EU-governmental economic data. <em>German Economic Review</em>, <strong>12</strong>(3), 243–255.</li>
 </ul>
-        
-      </article>
+            
+          </article>
+        </div>
 
+      </div>
     </div>
   </main>
 
@@ -381,6 +409,10 @@ $$</p>
   </footer>
 
   <script src="../assets/js/navigation.js" defer></script>
+  <!-- Left "All writing" navigator -->
+  <script src="../assets/js/articleNav.js" defer></script>
+  <!-- Reading progress bar -->
+  <script src="../assets/js/readingProgress.js" defer></script>
 
 </body>
 </html>

--- a/til/linearity-of-expectation-til.html
+++ b/til/linearity-of-expectation-til.html
@@ -128,10 +128,26 @@
       color: var(--color-text-muted);
       letter-spacing: 0.06em;
     }
+
+    /* === Reading layout: left navigator + content === */
+    .til-layout { display: block; }
+
+    @media (min-width: 1440px) {
+      .site-main .container--wide { max-width: 1360px; }
+      .til-layout {
+        display: grid;
+        grid-template-columns: 210px minmax(0, var(--container-max));
+        gap: var(--space-12);
+        justify-content: center;
+      }
+      .article-nav { display: block; }
+      /* header and prose already max-width 780 + auto margins; fill the column */
+    }
   </style>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
 
   <header class="site-header" role="banner">
     <div class="container container--wide">
@@ -152,21 +168,31 @@
 
   <main class="site-main" id="main-content">
     <div class="container container--wide">
+      <div class="til-layout">
 
-      <header class="til-header">
-        <a href="../til.html" class="til-header__back">← TIL</a>
-        <p class="til-header__kicker">Today I Learned</p>
-        <h1 class="til-header__title">The Most Useful Theorem in Probability Has No Independence Hypothesis</h1>
-        <div class="til-header__meta">
-          <time class="til-header__date" datetime="2026-07-11">Jul 2026</time>
-          <div class="tags">
-            <span class="tag" data-category="til">til</span><span class="tag">probability</span><span class="tag">expectation</span><span class="tag">correlation</span>
-          </div>
-        </div>
-      </header>
+        <!-- All writing — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All writing">
+          <nav class="article-nav__inner">
+            <p class="article-nav__title">All writing</p>
+            <ul class="article-nav__list" id="article-nav-list"></ul>
+          </nav>
+        </aside>
 
-      <article class="til-prose" aria-label="TIL content">
-        <h1 id="the-most-useful-theorem-in-probability-has-no-independence-hypothesis">The Most Useful Theorem in Probability Has No Independence Hypothesis</h1>
+        <div class="til-main">
+          <header class="til-header">
+            <a href="../til.html" class="til-header__back">← TIL</a>
+            <p class="til-header__kicker">Today I Learned</p>
+            <h1 class="til-header__title">The Most Useful Theorem in Probability Has No Independence Hypothesis</h1>
+            <div class="til-header__meta">
+              <time class="til-header__date" datetime="2026-07-11">Jul 2026</time>
+              <div class="tags">
+                <span class="tag" data-category="til">til</span><span class="tag">probability</span><span class="tag">expectation</span><span class="tag">correlation</span>
+              </div>
+            </div>
+          </header>
+
+          <article class="til-prose" aria-label="TIL content">
+            <h1 id="the-most-useful-theorem-in-probability-has-no-independence-hypothesis">The Most Useful Theorem in Probability Has No Independence Hypothesis</h1>
 <blockquote>
 <p><strong>What this is.</strong> The one everyday result in probability that needs no independence hypothesis — and why that makes the mean of a budget trustworthy while its risk band stays fragile. You should be comfortable with expectation, variance, and correlation. By the end you will know which half of a forecast survives correlated inputs, and which half does not. Figure and numbers reproduce from the <a href="https://github.com/brunoramosmartins/linearity-of-expectation-til">companion repository</a>.</p>
 </blockquote>
@@ -199,9 +225,11 @@ $$</p>
 <p>The failure mode I see most often is treating the second with tools that worked for the first. Result: budgets whose central estimates are right and whose risk bands are off by a factor of three. The quarter when everything correlates at once is the quarter that destroys the margin of safety.</p>
 <hr />
 <p><em>The figure and every number above are reproduced by versioned scripts with fixed seeds in the <a href="https://github.com/brunoramosmartins/linearity-of-expectation-til">companion repository</a>.</em></p>
-        
-      </article>
+            
+          </article>
+        </div>
 
+      </div>
     </div>
   </main>
 
@@ -217,6 +245,10 @@ $$</p>
   </footer>
 
   <script src="../assets/js/navigation.js" defer></script>
+  <!-- Left "All writing" navigator -->
+  <script src="../assets/js/articleNav.js" defer></script>
+  <!-- Reading progress bar -->
+  <script src="../assets/js/readingProgress.js" defer></script>
 
 </body>
 </html>


### PR DESCRIPTION
- Remove nl2br so hard-wrapped prose renders as normal paragraphs
- Escape Monte Carlo currency (R\$) so MathJax renders it literally
- Left 'All writing' navigator (sticky, newest-first) on article/TIL pages at >=1440px
- Reading progress bar that fills on scroll