### PR TITLE
feat(ux): reading experience + prose rendering fixes

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -721,6 +721,32 @@
   border-right: 1px solid var(--color-border);
 }
 
+/* Slim, unobtrusive scrollbar for the sticky reading panels — replaces the
+   chunky default track. Thumb is a soft rounded bar that only firms up on
+   hover; the track is invisible. Shared by the left rail and On This Page. */
+.article-nav__inner,
+.article-toc__inner {
+  scrollbar-width: thin;                              /* Firefox */
+  scrollbar-color: var(--color-border) transparent;
+}
+.article-nav__inner::-webkit-scrollbar,
+.article-toc__inner::-webkit-scrollbar {
+  width: 6px;
+}
+.article-nav__inner::-webkit-scrollbar-track,
+.article-toc__inner::-webkit-scrollbar-track {
+  background: transparent;
+}
+.article-nav__inner::-webkit-scrollbar-thumb,
+.article-toc__inner::-webkit-scrollbar-thumb {
+  background-color: var(--color-border);
+  border-radius: 999px;
+}
+.article-nav__inner:hover::-webkit-scrollbar-thumb,
+.article-toc__inner:hover::-webkit-scrollbar-thumb {
+  background-color: var(--color-text-muted);
+}
+
 .article-nav__title {
   font-family: var(--font-mono);
   font-size: var(--text-xs);

--- a/assets/js/articleNav.js
+++ b/assets/js/articleNav.js
@@ -1,9 +1,11 @@
 /**
- * articleNav.js — left-hand "All writing" panel for article and TIL pages.
+ * articleNav.js — left-hand navigator for article and TIL pages.
  *
- * Fetches data/articles.json, lists every piece newest-first, links to each,
- * and highlights the current page. The panel is position:sticky (set in CSS),
- * so it stays put while the article scrolls — same behaviour as On This Page.
+ * Fetches data/articles.json and lists sibling pieces newest-first, linking to
+ * each and highlighting the current page. The list is scoped to the page type:
+ * on an article page it shows only articles, on a TIL page only TILs — a reader
+ * inside Articles never sees TILs in the rail, and vice-versa. The panel is
+ * position:sticky (set in CSS), so it stays put while the page scrolls.
  *
  * Plain script (no modules), loaded with `defer`.
  */
@@ -25,10 +27,18 @@
   }
 
   var here = location.pathname; // e.g. /posts/foo.html or /til/bar.html
+  var onTil = /\/til\//.test(here);
+
+  // Retitle the rail to match the scope, since it no longer lists everything.
+  var titleEl = navEl.querySelector('.article-nav__title');
+  if (titleEl) titleEl.textContent = onTil ? 'All TILs' : 'All articles';
 
   fetch('../data/articles.json')
     .then(function (r) { return r.json(); })
     .then(function (items) {
+      items = items.filter(function (it) {
+        return (it.category === 'til') === onTil;
+      });
       items.sort(function (a, b) {
         return (b.date || '').localeCompare(a.date || '');
       });
@@ -50,8 +60,7 @@
 
         var meta = document.createElement('span');
         meta.className = 'article-nav__meta';
-        meta.textContent = formatDate(it.date) +
-          (it.category === 'til' ? ' · TIL' : '');
+        meta.textContent = formatDate(it.date);
         a.appendChild(meta);
 
         li.appendChild(a);

--- a/assets/js/articleToc.js
+++ b/assets/js/articleToc.js
@@ -47,6 +47,12 @@
 
   tocList.appendChild(fragment);
 
+  // Sliding rail marker — a single accent bar that tracks the active section.
+  var marker = document.createElement('span');
+  marker.className = 'article-toc__marker';
+  marker.setAttribute('aria-hidden', 'true');
+  tocList.appendChild(marker);
+
   /* --- Hover anchor links on headings ------------------------------------ */
   anchorTargets.forEach(function (heading) {
     var anchor = document.createElement('a');
@@ -60,12 +66,22 @@
   /* --- Scroll spy --------------------------------------------------------- */
   var activeLink = null;
 
+  // Align the rail marker to a link's vertical extent within the list.
+  // (The list is position:relative, so offsetTop/offsetHeight are relative
+  // to it — the marker's own coordinate system.)
+  function moveMarker(link) {
+    marker.style.height = link.offsetHeight + 'px';
+    marker.style.transform = 'translateY(' + link.offsetTop + 'px)';
+    marker.style.opacity = '1';
+  }
+
   function setActive(id) {
     var link = linkById[id];
     if (link === activeLink) return;
     if (activeLink) activeLink.classList.remove('active');
     link.classList.add('active');
     activeLink = link;
+    moveMarker(link);
   }
 
   function onScroll() {
@@ -89,7 +105,17 @@
     }, 80);
   }
 
+  // Reposition the marker after layout shifts (font load, resize) without
+  // waiting for a scroll — the active link may have moved.
+  function reposition() {
+    if (activeLink) moveMarker(activeLink);
+  }
+
   document.addEventListener('scroll', onScrollThrottled, { passive: true });
-  window.addEventListener('resize', onScrollThrottled, { passive: true });
+  window.addEventListener('resize', function () {
+    onScrollThrottled();
+    reposition();
+  }, { passive: true });
+  window.addEventListener('load', reposition);
   onScroll();
 })();

--- a/posts/bayesian-fyf.html
+++ b/posts/bayesian-fyf.html
@@ -193,8 +193,6 @@
       top: calc(var(--header-height) + var(--space-6));
       max-height: calc(100vh - var(--header-height) - var(--space-12));
       overflow-y: auto;
-      padding-left: var(--space-4);
-      border-left: 1px solid var(--color-border);
     }
 
     .article-toc__title {
@@ -204,12 +202,31 @@
       letter-spacing: 0.08em;
       color: var(--color-text-muted);
       margin-bottom: var(--space-4);
+      padding-left: var(--space-4);   /* line up with the topic labels */
     }
 
+    /* The list carries the vertical rail; a single accent marker slides along
+       it to the section being read (positioned by articleToc.js). */
     .article-toc__list {
+      position: relative;
       list-style: none;
-      padding: 0;
       margin: 0;
+      padding: 0 0 0 var(--space-4);
+      border-left: 1px solid var(--color-border);
+    }
+
+    .article-toc__marker {
+      position: absolute;
+      left: -1px;                    /* sit on top of the 1px rail */
+      top: 0;
+      width: 2px;
+      height: 0;                     /* height + offset set by JS */
+      background-color: var(--color-accent);
+      border-radius: 999px;
+      opacity: 0;
+      transition: transform var(--transition-base),
+                  height var(--transition-base),
+                  opacity var(--transition-fast);
     }
 
     .article-toc__item { margin-bottom: var(--space-2); }
@@ -279,10 +296,10 @@
 
       <div class="article-layout">
 
-        <!-- All writing — populated by articleNav.js from articles.json -->
-        <aside class="article-nav" aria-label="All writing">
+        <!-- Sibling articles — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All articles">
           <nav class="article-nav__inner">
-            <p class="article-nav__title">All writing</p>
+            <p class="article-nav__title">All articles</p>
             <ul class="article-nav__list" id="article-nav-list"></ul>
           </nav>
         </aside>

--- a/posts/headcount-dynamics.html
+++ b/posts/headcount-dynamics.html
@@ -193,8 +193,6 @@
       top: calc(var(--header-height) + var(--space-6));
       max-height: calc(100vh - var(--header-height) - var(--space-12));
       overflow-y: auto;
-      padding-left: var(--space-4);
-      border-left: 1px solid var(--color-border);
     }
 
     .article-toc__title {
@@ -204,12 +202,31 @@
       letter-spacing: 0.08em;
       color: var(--color-text-muted);
       margin-bottom: var(--space-4);
+      padding-left: var(--space-4);   /* line up with the topic labels */
     }
 
+    /* The list carries the vertical rail; a single accent marker slides along
+       it to the section being read (positioned by articleToc.js). */
     .article-toc__list {
+      position: relative;
       list-style: none;
-      padding: 0;
       margin: 0;
+      padding: 0 0 0 var(--space-4);
+      border-left: 1px solid var(--color-border);
+    }
+
+    .article-toc__marker {
+      position: absolute;
+      left: -1px;                    /* sit on top of the 1px rail */
+      top: 0;
+      width: 2px;
+      height: 0;                     /* height + offset set by JS */
+      background-color: var(--color-accent);
+      border-radius: 999px;
+      opacity: 0;
+      transition: transform var(--transition-base),
+                  height var(--transition-base),
+                  opacity var(--transition-fast);
     }
 
     .article-toc__item { margin-bottom: var(--space-2); }
@@ -279,10 +296,10 @@
 
       <div class="article-layout">
 
-        <!-- All writing — populated by articleNav.js from articles.json -->
-        <aside class="article-nav" aria-label="All writing">
+        <!-- Sibling articles — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All articles">
           <nav class="article-nav__inner">
-            <p class="article-nav__title">All writing</p>
+            <p class="article-nav__title">All articles</p>
             <ul class="article-nav__list" id="article-nav-list"></ul>
           </nav>
         </aside>

--- a/posts/krippendorff-alpha.html
+++ b/posts/krippendorff-alpha.html
@@ -193,8 +193,6 @@
       top: calc(var(--header-height) + var(--space-6));
       max-height: calc(100vh - var(--header-height) - var(--space-12));
       overflow-y: auto;
-      padding-left: var(--space-4);
-      border-left: 1px solid var(--color-border);
     }
 
     .article-toc__title {
@@ -204,12 +202,31 @@
       letter-spacing: 0.08em;
       color: var(--color-text-muted);
       margin-bottom: var(--space-4);
+      padding-left: var(--space-4);   /* line up with the topic labels */
     }
 
+    /* The list carries the vertical rail; a single accent marker slides along
+       it to the section being read (positioned by articleToc.js). */
     .article-toc__list {
+      position: relative;
       list-style: none;
-      padding: 0;
       margin: 0;
+      padding: 0 0 0 var(--space-4);
+      border-left: 1px solid var(--color-border);
+    }
+
+    .article-toc__marker {
+      position: absolute;
+      left: -1px;                    /* sit on top of the 1px rail */
+      top: 0;
+      width: 2px;
+      height: 0;                     /* height + offset set by JS */
+      background-color: var(--color-accent);
+      border-radius: 999px;
+      opacity: 0;
+      transition: transform var(--transition-base),
+                  height var(--transition-base),
+                  opacity var(--transition-fast);
     }
 
     .article-toc__item { margin-bottom: var(--space-2); }
@@ -279,10 +296,10 @@
 
       <div class="article-layout">
 
-        <!-- All writing — populated by articleNav.js from articles.json -->
-        <aside class="article-nav" aria-label="All writing">
+        <!-- Sibling articles — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All articles">
           <nav class="article-nav__inner">
-            <p class="article-nav__title">All writing</p>
+            <p class="article-nav__title">All articles</p>
             <ul class="article-nav__list" id="article-nav-list"></ul>
           </nav>
         </aside>

--- a/posts/monte-carlo-budget.html
+++ b/posts/monte-carlo-budget.html
@@ -193,8 +193,6 @@
       top: calc(var(--header-height) + var(--space-6));
       max-height: calc(100vh - var(--header-height) - var(--space-12));
       overflow-y: auto;
-      padding-left: var(--space-4);
-      border-left: 1px solid var(--color-border);
     }
 
     .article-toc__title {
@@ -204,12 +202,31 @@
       letter-spacing: 0.08em;
       color: var(--color-text-muted);
       margin-bottom: var(--space-4);
+      padding-left: var(--space-4);   /* line up with the topic labels */
     }
 
+    /* The list carries the vertical rail; a single accent marker slides along
+       it to the section being read (positioned by articleToc.js). */
     .article-toc__list {
+      position: relative;
       list-style: none;
-      padding: 0;
       margin: 0;
+      padding: 0 0 0 var(--space-4);
+      border-left: 1px solid var(--color-border);
+    }
+
+    .article-toc__marker {
+      position: absolute;
+      left: -1px;                    /* sit on top of the 1px rail */
+      top: 0;
+      width: 2px;
+      height: 0;                     /* height + offset set by JS */
+      background-color: var(--color-accent);
+      border-radius: 999px;
+      opacity: 0;
+      transition: transform var(--transition-base),
+                  height var(--transition-base),
+                  opacity var(--transition-fast);
     }
 
     .article-toc__item { margin-bottom: var(--space-2); }
@@ -279,10 +296,10 @@
 
       <div class="article-layout">
 
-        <!-- All writing — populated by articleNav.js from articles.json -->
-        <aside class="article-nav" aria-label="All writing">
+        <!-- Sibling articles — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All articles">
           <nav class="article-nav__inner">
-            <p class="article-nav__title">All writing</p>
+            <p class="article-nav__title">All articles</p>
             <ul class="article-nav__list" id="article-nav-list"></ul>
           </nav>
         </aside>

--- a/posts/not-all-errors-cost-the-same.html
+++ b/posts/not-all-errors-cost-the-same.html
@@ -193,8 +193,6 @@
       top: calc(var(--header-height) + var(--space-6));
       max-height: calc(100vh - var(--header-height) - var(--space-12));
       overflow-y: auto;
-      padding-left: var(--space-4);
-      border-left: 1px solid var(--color-border);
     }
 
     .article-toc__title {
@@ -204,12 +202,31 @@
       letter-spacing: 0.08em;
       color: var(--color-text-muted);
       margin-bottom: var(--space-4);
+      padding-left: var(--space-4);   /* line up with the topic labels */
     }
 
+    /* The list carries the vertical rail; a single accent marker slides along
+       it to the section being read (positioned by articleToc.js). */
     .article-toc__list {
+      position: relative;
       list-style: none;
-      padding: 0;
       margin: 0;
+      padding: 0 0 0 var(--space-4);
+      border-left: 1px solid var(--color-border);
+    }
+
+    .article-toc__marker {
+      position: absolute;
+      left: -1px;                    /* sit on top of the 1px rail */
+      top: 0;
+      width: 2px;
+      height: 0;                     /* height + offset set by JS */
+      background-color: var(--color-accent);
+      border-radius: 999px;
+      opacity: 0;
+      transition: transform var(--transition-base),
+                  height var(--transition-base),
+                  opacity var(--transition-fast);
     }
 
     .article-toc__item { margin-bottom: var(--space-2); }
@@ -279,10 +296,10 @@
 
       <div class="article-layout">
 
-        <!-- All writing — populated by articleNav.js from articles.json -->
-        <aside class="article-nav" aria-label="All writing">
+        <!-- Sibling articles — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All articles">
           <nav class="article-nav__inner">
-            <p class="article-nav__title">All writing</p>
+            <p class="article-nav__title">All articles</p>
             <ul class="article-nav__list" id="article-nav-list"></ul>
           </nav>
         </aside>

--- a/posts/probabilistic-cost-modelling.html
+++ b/posts/probabilistic-cost-modelling.html
@@ -193,8 +193,6 @@
       top: calc(var(--header-height) + var(--space-6));
       max-height: calc(100vh - var(--header-height) - var(--space-12));
       overflow-y: auto;
-      padding-left: var(--space-4);
-      border-left: 1px solid var(--color-border);
     }
 
     .article-toc__title {
@@ -204,12 +202,31 @@
       letter-spacing: 0.08em;
       color: var(--color-text-muted);
       margin-bottom: var(--space-4);
+      padding-left: var(--space-4);   /* line up with the topic labels */
     }
 
+    /* The list carries the vertical rail; a single accent marker slides along
+       it to the section being read (positioned by articleToc.js). */
     .article-toc__list {
+      position: relative;
       list-style: none;
-      padding: 0;
       margin: 0;
+      padding: 0 0 0 var(--space-4);
+      border-left: 1px solid var(--color-border);
+    }
+
+    .article-toc__marker {
+      position: absolute;
+      left: -1px;                    /* sit on top of the 1px rail */
+      top: 0;
+      width: 2px;
+      height: 0;                     /* height + offset set by JS */
+      background-color: var(--color-accent);
+      border-radius: 999px;
+      opacity: 0;
+      transition: transform var(--transition-base),
+                  height var(--transition-base),
+                  opacity var(--transition-fast);
     }
 
     .article-toc__item { margin-bottom: var(--space-2); }
@@ -279,10 +296,10 @@
 
       <div class="article-layout">
 
-        <!-- All writing — populated by articleNav.js from articles.json -->
-        <aside class="article-nav" aria-label="All writing">
+        <!-- Sibling articles — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All articles">
           <nav class="article-nav__inner">
-            <p class="article-nav__title">All writing</p>
+            <p class="article-nav__title">All articles</p>
             <ul class="article-nav__list" id="article-nav-list"></ul>
           </nav>
         </aside>

--- a/templates/article_template.html
+++ b/templates/article_template.html
@@ -193,8 +193,6 @@
       top: calc(var(--header-height) + var(--space-6));
       max-height: calc(100vh - var(--header-height) - var(--space-12));
       overflow-y: auto;
-      padding-left: var(--space-4);
-      border-left: 1px solid var(--color-border);
     }
 
     .article-toc__title {
@@ -204,12 +202,31 @@
       letter-spacing: 0.08em;
       color: var(--color-text-muted);
       margin-bottom: var(--space-4);
+      padding-left: var(--space-4);   /* line up with the topic labels */
     }
 
+    /* The list carries the vertical rail; a single accent marker slides along
+       it to the section being read (positioned by articleToc.js). */
     .article-toc__list {
+      position: relative;
       list-style: none;
-      padding: 0;
       margin: 0;
+      padding: 0 0 0 var(--space-4);
+      border-left: 1px solid var(--color-border);
+    }
+
+    .article-toc__marker {
+      position: absolute;
+      left: -1px;                    /* sit on top of the 1px rail */
+      top: 0;
+      width: 2px;
+      height: 0;                     /* height + offset set by JS */
+      background-color: var(--color-accent);
+      border-radius: 999px;
+      opacity: 0;
+      transition: transform var(--transition-base),
+                  height var(--transition-base),
+                  opacity var(--transition-fast);
     }
 
     .article-toc__item { margin-bottom: var(--space-2); }
@@ -279,10 +296,10 @@
 
       <div class="article-layout">
 
-        <!-- All writing — populated by articleNav.js from articles.json -->
-        <aside class="article-nav" aria-label="All writing">
+        <!-- Sibling articles — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All articles">
           <nav class="article-nav__inner">
-            <p class="article-nav__title">All writing</p>
+            <p class="article-nav__title">All articles</p>
             <ul class="article-nav__list" id="article-nav-list"></ul>
           </nav>
         </aside>

--- a/templates/til_template.html
+++ b/templates/til_template.html
@@ -141,7 +141,16 @@
         justify-content: center;
       }
       .article-nav { display: block; }
-      /* header and prose already max-width 780 + auto margins; fill the column */
+
+      /* Title spans both columns so the navigator (row 2, col 1) begins
+         below it — same feel as the article page, where the header sits
+         above the reading grid rather than beside the rail. */
+      .til-layout .til-header {
+        grid-column: 1 / -1;
+        max-width: none;
+        margin-left: 0;
+        margin-right: 0;
+      }
     }
   </style>
 </head>
@@ -170,32 +179,31 @@
     <div class="container container--wide">
       <div class="til-layout">
 
-        <!-- All writing — populated by articleNav.js from articles.json -->
-        <aside class="article-nav" aria-label="All writing">
+        <!-- Title spans the grid; the navigator below it lists sibling TILs -->
+        <header class="til-header">
+          <a href="../til.html" class="til-header__back">← TIL</a>
+          <p class="til-header__kicker">Today I Learned</p>
+          <h1 class="til-header__title">{{article_title}}</h1>
+          <div class="til-header__meta">
+            <time class="til-header__date" datetime="{{article_date_iso}}">{{article_date}}</time>
+            <div class="tags">
+              {{article_tags}}
+            </div>
+          </div>
+        </header>
+
+        <!-- Sibling TILs — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All TILs">
           <nav class="article-nav__inner">
-            <p class="article-nav__title">All writing</p>
+            <p class="article-nav__title">All TILs</p>
             <ul class="article-nav__list" id="article-nav-list"></ul>
           </nav>
         </aside>
 
-        <div class="til-main">
-          <header class="til-header">
-            <a href="../til.html" class="til-header__back">← TIL</a>
-            <p class="til-header__kicker">Today I Learned</p>
-            <h1 class="til-header__title">{{article_title}}</h1>
-            <div class="til-header__meta">
-              <time class="til-header__date" datetime="{{article_date_iso}}">{{article_date}}</time>
-              <div class="tags">
-                {{article_tags}}
-              </div>
-            </div>
-          </header>
-
-          <article class="til-prose" aria-label="TIL content">
-            {{article_content}}
-            {{cross_link_box}}
-          </article>
-        </div>
+        <article class="til-prose" aria-label="TIL content">
+          {{article_content}}
+          {{cross_link_box}}
+        </article>
 
       </div>
     </div>

--- a/til/benfords-law.html
+++ b/til/benfords-law.html
@@ -141,7 +141,16 @@
         justify-content: center;
       }
       .article-nav { display: block; }
-      /* header and prose already max-width 780 + auto margins; fill the column */
+
+      /* Title spans both columns so the navigator (row 2, col 1) begins
+         below it — same feel as the article page, where the header sits
+         above the reading grid rather than beside the rail. */
+      .til-layout .til-header {
+        grid-column: 1 / -1;
+        max-width: none;
+        margin-left: 0;
+        margin-right: 0;
+      }
     }
   </style>
 </head>
@@ -170,29 +179,29 @@
     <div class="container container--wide">
       <div class="til-layout">
 
-        <!-- All writing — populated by articleNav.js from articles.json -->
-        <aside class="article-nav" aria-label="All writing">
+        <!-- Title spans the grid; the navigator below it lists sibling TILs -->
+        <header class="til-header">
+          <a href="../til.html" class="til-header__back">← TIL</a>
+          <p class="til-header__kicker">Today I Learned</p>
+          <h1 class="til-header__title">Benford's Law: two derivations, four tests, one fraud detector</h1>
+          <div class="til-header__meta">
+            <time class="til-header__date" datetime="2026-05-03">May 2026</time>
+            <div class="tags">
+              <span class="tag" data-category="til">til</span><span class="tag">statistics</span><span class="tag">fraud-detection</span><span class="tag">mathematics</span><span class="tag">audit</span>
+            </div>
+          </div>
+        </header>
+
+        <!-- Sibling TILs — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All TILs">
           <nav class="article-nav__inner">
-            <p class="article-nav__title">All writing</p>
+            <p class="article-nav__title">All TILs</p>
             <ul class="article-nav__list" id="article-nav-list"></ul>
           </nav>
         </aside>
 
-        <div class="til-main">
-          <header class="til-header">
-            <a href="../til.html" class="til-header__back">← TIL</a>
-            <p class="til-header__kicker">Today I Learned</p>
-            <h1 class="til-header__title">Benford's Law: two derivations, four tests, one fraud detector</h1>
-            <div class="til-header__meta">
-              <time class="til-header__date" datetime="2026-05-03">May 2026</time>
-              <div class="tags">
-                <span class="tag" data-category="til">til</span><span class="tag">statistics</span><span class="tag">fraud-detection</span><span class="tag">mathematics</span><span class="tag">audit</span>
-              </div>
-            </div>
-          </header>
-
-          <article class="til-prose" aria-label="TIL content">
-            <h1 id="benfords-law-two-derivations-four-tests-one-fraud-detector">Benford's Law: two derivations, four tests, one fraud detector</h1>
+        <article class="til-prose" aria-label="TIL content">
+          <h1 id="benfords-law-two-derivations-four-tests-one-fraud-detector">Benford's Law: two derivations, four tests, one fraud detector</h1>
 <blockquote>
 <p><strong>What this is.</strong> The first digit of "natural" numerical data is not uniform but logarithmic: $P(d) = \log_{10}(1 + 1/d)$, so a leading 1 occurs about 30% of the time and a leading 9 less than 5%. This note reconstructs the law from two independent arguments — one probabilistic, one structural — shows real data landing on the curve, and closes the loop with a fraud-detection demo. It started as a margin note while rereading <em>The Drunkard's Walk</em>.</p>
 <p><strong>What you should know before reading.</strong> Comfort with logarithms, basic probability (PMF, CDF), and the idea of a hypothesis test. The measure-theoretic asides (Haar measure, equidistribution) are stated, not required.</p>
@@ -392,9 +401,8 @@ $$</p>
 <li>Berger, A. &amp; Hill, T. P. (2015). <em>An Introduction to Benford's Law</em>. Princeton University Press.</li>
 <li>Rauch, B., Göttsche, M., Brähler, G. &amp; Engel, S. (2011). Fact and fiction in EU-governmental economic data. <em>German Economic Review</em>, <strong>12</strong>(3), 243–255.</li>
 </ul>
-            
-          </article>
-        </div>
+          
+        </article>
 
       </div>
     </div>

--- a/til/linearity-of-expectation-til.html
+++ b/til/linearity-of-expectation-til.html
@@ -141,7 +141,16 @@
         justify-content: center;
       }
       .article-nav { display: block; }
-      /* header and prose already max-width 780 + auto margins; fill the column */
+
+      /* Title spans both columns so the navigator (row 2, col 1) begins
+         below it — same feel as the article page, where the header sits
+         above the reading grid rather than beside the rail. */
+      .til-layout .til-header {
+        grid-column: 1 / -1;
+        max-width: none;
+        margin-left: 0;
+        margin-right: 0;
+      }
     }
   </style>
 </head>
@@ -170,29 +179,29 @@
     <div class="container container--wide">
       <div class="til-layout">
 
-        <!-- All writing — populated by articleNav.js from articles.json -->
-        <aside class="article-nav" aria-label="All writing">
+        <!-- Title spans the grid; the navigator below it lists sibling TILs -->
+        <header class="til-header">
+          <a href="../til.html" class="til-header__back">← TIL</a>
+          <p class="til-header__kicker">Today I Learned</p>
+          <h1 class="til-header__title">The Most Useful Theorem in Probability Has No Independence Hypothesis</h1>
+          <div class="til-header__meta">
+            <time class="til-header__date" datetime="2026-07-11">Jul 2026</time>
+            <div class="tags">
+              <span class="tag" data-category="til">til</span><span class="tag">probability</span><span class="tag">expectation</span><span class="tag">correlation</span>
+            </div>
+          </div>
+        </header>
+
+        <!-- Sibling TILs — populated by articleNav.js from articles.json -->
+        <aside class="article-nav" aria-label="All TILs">
           <nav class="article-nav__inner">
-            <p class="article-nav__title">All writing</p>
+            <p class="article-nav__title">All TILs</p>
             <ul class="article-nav__list" id="article-nav-list"></ul>
           </nav>
         </aside>
 
-        <div class="til-main">
-          <header class="til-header">
-            <a href="../til.html" class="til-header__back">← TIL</a>
-            <p class="til-header__kicker">Today I Learned</p>
-            <h1 class="til-header__title">The Most Useful Theorem in Probability Has No Independence Hypothesis</h1>
-            <div class="til-header__meta">
-              <time class="til-header__date" datetime="2026-07-11">Jul 2026</time>
-              <div class="tags">
-                <span class="tag" data-category="til">til</span><span class="tag">probability</span><span class="tag">expectation</span><span class="tag">correlation</span>
-              </div>
-            </div>
-          </header>
-
-          <article class="til-prose" aria-label="TIL content">
-            <h1 id="the-most-useful-theorem-in-probability-has-no-independence-hypothesis">The Most Useful Theorem in Probability Has No Independence Hypothesis</h1>
+        <article class="til-prose" aria-label="TIL content">
+          <h1 id="the-most-useful-theorem-in-probability-has-no-independence-hypothesis">The Most Useful Theorem in Probability Has No Independence Hypothesis</h1>
 <blockquote>
 <p><strong>What this is.</strong> The one everyday result in probability that needs no independence hypothesis — and why that makes the mean of a budget trustworthy while its risk band stays fragile. You should be comfortable with expectation, variance, and correlation. By the end you will know which half of a forecast survives correlated inputs, and which half does not. Figure and numbers reproduce from the <a href="https://github.com/brunoramosmartins/linearity-of-expectation-til">companion repository</a>.</p>
 </blockquote>
@@ -225,9 +234,8 @@ $$</p>
 <p>The failure mode I see most often is treating the second with tools that worked for the first. Result: budgets whose central estimates are right and whose risk bands are off by a factor of three. The quarter when everything correlates at once is the quarter that destroys the margin of safety.</p>
 <hr />
 <p><em>The figure and every number above are reproduced by versioned scripts with fixed seeds in the <a href="https://github.com/brunoramosmartins/linearity-of-expectation-til">companion repository</a>.</em></p>
-            
-          </article>
-        </div>
+          
+        </article>
 
       </div>
     </div>


### PR DESCRIPTION
## Context

This branch groups the reading-experience and prose-rendering work that sits on
top of the v0.9 content release. It touches two layers of the blog engine: the
Markdown → HTML build path (how paragraphs and currency render) and the article/
TIL page shells (navigation, progress, table of contents). No content sources are
restructured — articles remain single-repo sources synced through the existing
pipeline.

---

## Objective

Make long-form articles and TILs read cleanly end to end: prose flows as real
paragraphs instead of hard-wrapped lines, currency renders correctly, and the
page furniture (side navigator, progress bar, "On this page") is scoped, aligned,
and unobtrusive.

---

## Scope Delivered

- [x] Drop `nl2br` so hard-wrapped Markdown renders as normal paragraphs; document currency escaping
- [x] Rebuild all articles without forced line breaks; fix Monte Carlo currency rendering
- [x] Editorial pass on the three published articles (Krippendorff, Not All Errors, Benford)
- [x] Left "All writing" navigator + reading-progress bar on articles and TILs
- [x] Scope the side navigator by page type — articles list only articles, TILs list only TILs
- [x] TIL title now spans the grid so the navigator begins below it (parity with article pages)
- [x] "On this page" gains a sliding rail marker that tracks the active section
- [x] Slim, hover-aware scrollbars on both side panels

---

## Architectural Impact

- **Structure** — `til_template.html` reworked so the header is a full-width grid
  row; the `.til-main` wrapper is removed. `articleNav.js` now filters
  `articles.json` by category against the current path. No changes to the sync or
  data contract.
- **Documentation** — currency-escaping guidance captured in `WRITING-GUIDE.md`
  and the `build_blog.py` docstring.
- **Governance** — regenerated `posts/` and `til/` HTML are committed as
  build artifacts, consistent with the existing publish flow.
- **Future milestones** — the rail marker and scroll-spy in `articleToc.js` are
  reusable if TILs later adopt an "On this page" panel (deliberately deferred
  while TILs stay short).

---

## Validation

- [x] No structural conflicts
- [x] Branch strategy respected (`feature/* → main` via PR)
- [x] `python build_blog.py` rebuilds cleanly (8/8 articles)
- [ ] README updated — not required; no architecture/roadmap change